### PR TITLE
fix: added incremental retries & fixed 2FA bug

### DIFF
--- a/optexity/inference/core/run_two_fa.py
+++ b/optexity/inference/core/run_two_fa.py
@@ -49,9 +49,9 @@ async def run_two_fa_action(two_fa_action: TwoFAAction, memory: Memory):
                 if isinstance(response.code, str):
                     code = response.code
                 elif isinstance(response.code, list):
-                    if len(response.code) > 0:
+                    if len(response.code) > 1:
                         raise ValueError(f"Multiple 2FA codes found, {response.code}")
-                    else:
+                    elif len(response.code) == 1:
                         code = response.code[0]
 
             if code is not None:

--- a/optexity/inference/models/llm_model.py
+++ b/optexity/inference/models/llm_model.py
@@ -1,5 +1,6 @@
 import ast
 import logging
+import random
 import re
 import time
 from enum import Enum, unique
@@ -65,14 +66,16 @@ class LLMModel:
     ) -> tuple[str, TokenUsage]:
 
         max_retries = 3
+        base_delay = 2
         for i in range(max_retries):
             try:
                 return self._get_model_response(prompt, system_instruction)
             except Exception as e:
                 logger.error(f"LLM Error during inference: {e}")
                 if i < max_retries - 1:
-                    logger.info(f"Retrying... {i + 1}/{max_retries}")
-                    time.sleep(5)
+                    delay = base_delay * (2 ** i) + random.uniform(0, 1)
+                    logger.info(f"Retrying in {delay:.1f}s... {i + 1}/{max_retries}")
+                    time.sleep(delay)
                 continue
         raise Exception("Max retries exceeded for LLM")
 
@@ -87,10 +90,10 @@ class LLMModel:
 
         total_token_usage = TokenUsage()
         max_retries = 3
+        base_delay = 5
         last_exception = ""
         for i in range(max_retries):
             try:
-                # raise Exception("Test error")
                 parsed_response, token_usage = (
                     self._get_model_response_with_structured_output(
                         prompt=prompt,
@@ -106,8 +109,9 @@ class LLMModel:
             except Exception as e:
                 logger.error(f"LLM with structured output Error during inference: {e}")
                 if i < max_retries - 1:
-                    logger.info(f"Retrying... {i + 1}/{max_retries}")
-                    time.sleep(20)
+                    delay = base_delay * (2 ** i) + random.uniform(0, 2)
+                    logger.info(f"Retrying in {delay:.1f}s... {i + 1}/{max_retries}")
+                    time.sleep(delay)
                 last_exception = str(e)
 
         raise Exception(


### PR DESCRIPTION
- Replaced fixed time.sleep delays with an exponential backoff strategy that doubles the wait time after each retry attempt.
- 
- Added random jitter (0–2 seconds) to the backoff duration to mitigate the thundering herd problem, preventing concurrent retries from synchronizing and overwhelming the LLM provider.
- 
- This approach improves overall system resilience during API outages and rate-limit events by smoothing retry traffic and reducing retry storms.