### PR TITLE
Bring locator into view and focus before dispatching actions

### DIFF
--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -69,6 +69,10 @@ async def command_based_action_with_retry(
                 await locator.scroll_into_view_if_needed(
                     timeout=max_timeout_seconds_per_try * 1000
                 )
+                await locator.evaluate(
+                    "el => el.scrollIntoView({ block: 'center', inline: 'center' })"
+                )
+                await locator.focus()
                 await asyncio.sleep(0.05)
                 # browser_state_summary = await browser.get_browser_state_summary()
                 memory.browser_states[-1] = BrowserState(


### PR DESCRIPTION
## What this PR does
Brings the target element into view, centers it, and focuses it before executing actions using a locator.

## Related Issue
Fixes #16
