### PR TITLE
fix(lint): narrow ruff to F821 only; restore imports stripped by F401

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
               run: pre-commit run --all-files
 
             - name: Run Ruff (minimal strict)
-              run: ruff check . --select=F821,F401
+              run: ruff check . --select=F821

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       rev: v0.4.4
       hooks:
           - id: ruff
-            args: ["--select=F821,F401"]
+            args: ["--select=F821"]
 
     # --- Frontend formatting ---
     - repo: https://github.com/pre-commit/mirrors-prettier

--- a/optexity/inference/child_process.py
+++ b/optexity/inference/child_process.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import signal
+import subprocess
 import sys
 import uuid
 from contextlib import asynccontextmanager

--- a/optexity/inference/core/interaction/handle_captcha.py
+++ b/optexity/inference/core/interaction/handle_captcha.py
@@ -1,6 +1,8 @@
 import asyncio
 import base64
 import logging
+import time
+from pathlib import Path
 
 from playwright.async_api import Page
 from pydantic import BaseModel

--- a/optexity/inference/core/interaction/handle_select_utils.py
+++ b/optexity/inference/core/interaction/handle_select_utils.py
@@ -7,6 +7,7 @@ from optexity.inference.agents.select_value_prediction.select_value_prediction i
     SelectValuePredictionAgent,
 )
 from optexity.inference.models import get_llm_model_with_fallback
+from optexity.schema.actions.interaction_action import Locator
 from optexity.schema.memory import Memory
 from optexity.schema.task import Task
 

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -38,6 +38,7 @@ from optexity.schema.actions.interaction_action import DownloadUrlAsPdfAction
 from optexity.schema.automation import ActionNode, ForLoopNode, IfElseNode
 from optexity.schema.memory import BrowserState, ForLoopStatus, Memory, OutputData
 from optexity.schema.task import Task
+from optexity.utils.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/optexity/inference/infra/browser.py
+++ b/optexity/inference/infra/browser.py
@@ -14,9 +14,10 @@ from browser_use import Agent, BrowserSession, ChatGoogle
 from browser_use.browser.views import BrowserStateSummary
 from patchright._impl._errors import TimeoutError as PatchrightTimeoutError
 from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
-from playwright.async_api import Download, Locator, Request, Response
+from playwright.async_api import Download, Locator, Page, Request, Response
 
 from optexity.schema.memory import Memory, NetworkRequest, NetworkResponse
+from optexity.utils.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/optexity/inference/worker.py
+++ b/optexity/inference/worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 
 from optexity.inference.core.run_automation import run_automation

--- a/optexity/schema/actions/extraction_action.py
+++ b/optexity/schema/actions/extraction_action.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional
+from typing import Any, List, Literal, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator, model_validator

--- a/optexity/schema/actions/interaction_action.py
+++ b/optexity/schema/actions/interaction_action.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum, unique
 from typing import Any, Literal
 from uuid import uuid4

--- a/optexity/schema/memory.py
+++ b/optexity/schema/memory.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal


### PR DESCRIPTION
## Summary

PR #112 added ruff with \`--select=F821,F401\` and let \`F401\` auto-remove a batch of "unused" imports. Several of those imports are **not actually unused** — they're referenced via \`eval()\` on user-supplied Python script input at runtime, which static analysis can't see. Stripping them breaks user scripts.

This PR keeps the F821 check (catches genuine undefined-name bugs) but drops F401, and restores the 9 files whose imports were stripped.

## Changes

- \`.pre-commit-config.yaml\` + \`.github/workflows/lint.yml\`: \`--select=F821\` (dropped \`,F401\`) in both the pre-commit and the safety-net direct-ruff steps
- Restored 9 files to their pre-#112 state:
  - \`optexity/inference/child_process.py\` — \`subprocess\`
  - \`optexity/inference/core/interaction/handle_captcha.py\` — \`time\`, \`pathlib.Path\`
  - \`optexity/inference/core/interaction/handle_select_utils.py\` — \`Locator\`
  - \`optexity/inference/core/run_automation.py\` — \`settings\`
  - \`optexity/inference/infra/browser.py\` — \`Page\`, \`settings\`
  - \`optexity/inference/worker.py\` — \`json\`
  - \`optexity/schema/actions/extraction_action.py\` — \`typing.List\`
  - \`optexity/schema/actions/interaction_action.py\` — \`re\`
  - \`optexity/schema/memory.py\` — \`asyncio\`

## Why

F401 is a static check — it can only see what's referenced lexically. When code does \`eval(user_script)\`, the script can reference any name in the importing module's namespace, but ruff can't see that. Removing such imports silently breaks user scripts at runtime with NameError. F821 stays because it only flags *truly* undefined names, with no auto-removal risk.

## Test plan

- [x] \`pre-commit run ruff --files <all 9 restored files>\` → passes
- [x] CI lint job green
- [x] User scripts that previously used \`subprocess\`, \`json\`, etc. via \`eval()\` work again