### PR TITLE
fix: raise AxtreeIndexActionFailedException when browseruse can't act…

### DIFF
--- a/optexity/exceptions.py
+++ b/optexity/exceptions.py
@@ -12,3 +12,11 @@ class ElementNotFoundInAxtreeException(Exception):
         self.message = message
         self.original_error = original_error
         self.command = command
+
+
+class AxtreeIndexActionFailedException(Exception):
+    def __init__(self, message: str, index: int, original_error):
+        super().__init__(message)
+        self.message = message
+        self.index = index
+        self.original_error = original_error

--- a/optexity/inference/core/interaction/handle_click.py
+++ b/optexity/inference/core/interaction/handle_click.py
@@ -1,6 +1,7 @@
 import logging
 
 from optexity.exceptions import (
+    AxtreeIndexActionFailedException,
     ElementNotFoundInAxtreeException,
 )
 from optexity.inference.core.interaction.handle_command import (
@@ -75,20 +76,31 @@ async def click_element_index(
             action_model = browser.backend_agent.ActionModel(
                 **{"click": {"index": index, "button": click_element_action.button}}
             )
-            await browser.backend_agent.multi_act([action_model])
+            results = await browser.backend_agent.multi_act([action_model])
+            if results and results[0].error:
+                raise RuntimeError(
+                    f"browseruse click failed at index {index}: {results[0].error}"
+                )
 
-        if click_element_action.expect_download:
-            await handle_download(
-                _actual_click_element,
-                memory,
-                browser,
-                task,
-                click_element_action.download_filename,
+        try:
+            if click_element_action.expect_download:
+                await handle_download(
+                    _actual_click_element,
+                    memory,
+                    browser,
+                    task,
+                    click_element_action.download_filename,
+                )
+            else:
+                await _actual_click_element()
+        except Exception as e:
+            raise AxtreeIndexActionFailedException(
+                message=f"Failed to click element at axtree index {index}",
+                index=index,
+                original_error=e,
             )
-        else:
-            await _actual_click_element()
-    except ElementNotFoundInAxtreeException as e:
-        raise e
+    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+        raise
     except Exception as e:
         logger.error(f"Error in click_element_index: {e}")
         return

--- a/optexity/inference/core/interaction/handle_hover.py
+++ b/optexity/inference/core/interaction/handle_hover.py
@@ -1,6 +1,9 @@
 import logging
 
-from optexity.exceptions import ElementNotFoundInAxtreeException
+from optexity.exceptions import (
+    AxtreeIndexActionFailedException,
+    ElementNotFoundInAxtreeException,
+)
 from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
@@ -73,14 +76,18 @@ async def hover_element_index(
                 action_model = browser.backend_agent.ActionModel(
                     **{"hover": {"index": index}}
                 )
-                await browser.backend_agent.multi_act([action_model])
+                results = await browser.backend_agent.multi_act([action_model])
+                if results and results[0].error:
+                    raise RuntimeError(
+                        f"browseruse hover failed at index {index}: {results[0].error}"
+                    )
             except Exception as e:
                 logger.error(f"Error in hover_element_index: {e} trying right click")
                 node = await browser.backend_agent.browser_session.get_element_by_index(
                     index
                 )
                 if node is None:
-                    return
+                    raise
 
                 backend_page = (
                     await browser.backend_agent.browser_session.get_current_page()
@@ -88,9 +95,16 @@ async def hover_element_index(
                 element = await backend_page.get_element(node.backend_node_id)
                 await element.click(button="right")
 
-        await _actual_hover_element()
-    except ElementNotFoundInAxtreeException as e:
-        raise e
+        try:
+            await _actual_hover_element()
+        except Exception as e:
+            raise AxtreeIndexActionFailedException(
+                message=f"Failed to hover element at axtree index {index}",
+                index=index,
+                original_error=e,
+            )
+    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+        raise
     except Exception as e:
         logger.error(f"Error in hover_element_index: {e}")
         return

--- a/optexity/inference/core/interaction/handle_input.py
+++ b/optexity/inference/core/interaction/handle_input.py
@@ -1,7 +1,10 @@
 import logging
 import re
 
-from optexity.exceptions import ElementNotFoundInAxtreeException
+from optexity.exceptions import (
+    AxtreeIndexActionFailedException,
+    ElementNotFoundInAxtreeException,
+)
 from optexity.inference.agents.input_text_prediction.input_text_prediction import (
     InputTextPredictionAgent,
 )
@@ -151,9 +154,21 @@ async def input_text_index(
                 }
             }
         )
-        await browser.backend_agent.multi_act([action_model])
-    except ElementNotFoundInAxtreeException as e:
-        raise e
+
+        try:
+            results = await browser.backend_agent.multi_act([action_model])
+            if results and results[0].error:
+                raise RuntimeError(
+                    f"browseruse input failed at index {index}: {results[0].error}"
+                )
+        except Exception as e:
+            raise AxtreeIndexActionFailedException(
+                message=f"Failed to input text at axtree index {index}",
+                index=index,
+                original_error=e,
+            )
+    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+        raise
     except Exception as e:
         logger.error(f"Error in input_text_index: {e}")
         return

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -2,7 +2,10 @@ import logging
 
 from browser_use.dom.serializer.serializer import DOMTreeSerializer
 
-from optexity.exceptions import ElementNotFoundInAxtreeException
+from optexity.exceptions import (
+    AxtreeIndexActionFailedException,
+    ElementNotFoundInAxtreeException,
+)
 from optexity.inference.agents.select_option_prediction.select_option_prediction import (
     SelectOptionPredictionAgent,
 )
@@ -178,7 +181,11 @@ async def select_option_index(
 
         node = await browser.backend_agent.browser_session.get_element_by_index(index)
         if node is None:
-            return
+            raise AxtreeIndexActionFailedException(
+                message=f"Failed to resolve element at axtree index {index} for select_option",
+                index=index,
+                original_error="get_element_by_index returned None",
+            )
 
         select_option_values = DOMTreeSerializer(node)._extract_select_options(node)
         if select_option_values is None:
@@ -218,19 +225,30 @@ async def select_option_index(
                 logger.debug(
                     f"Playwright select_option succeeded: {playwright_success}"
                 )
+                if not playwright_success:
+                    raise RuntimeError(
+                        f"select_dropdown failed and playwright fallback miss: {results[0].error}"
+                    )
 
-        if select_option_action.expect_download:
-            await handle_download(
-                _actual_select_option,
-                memory,
-                browser,
-                task,
-                select_option_action.download_filename,
+        try:
+            if select_option_action.expect_download:
+                await handle_download(
+                    _actual_select_option,
+                    memory,
+                    browser,
+                    task,
+                    select_option_action.download_filename,
+                )
+            else:
+                await _actual_select_option()
+        except Exception as e:
+            raise AxtreeIndexActionFailedException(
+                message=f"Failed to select option at axtree index {index}",
+                index=index,
+                original_error=e,
             )
-        else:
-            await _actual_select_option()
-    except ElementNotFoundInAxtreeException as e:
-        raise e
+    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+        raise
     except Exception as e:
         logger.error(f"Error in select_option_index: {e}")
         return


### PR DESCRIPTION
… on axtree index

Adds a new AxtreeIndexActionFailedException raised from click/input/select/hover prompt-fallback paths when browseruse multi_act either throws or returns a result with .error populated (the latter is the common shadow-DOM failure mode). The new exception bypasses run_interaction_action's retry/classifier path so the automation fails cleanly instead of silently no-op'ing on unactionable indices.