### PR TITLE
ci(lint): add import smoke test to catch broken imports ruff misses

### DIFF
--- a/.github/scripts/import_smoke.py
+++ b/.github/scripts/import_smoke.py
@@ -1,0 +1,88 @@
+"""Recursively import every submodule of the named packages.
+
+Fails CI if any module raises ImportError, ModuleNotFoundError, or SyntaxError
+— catches things ruff/black can't, like `from typing import BaseException`
+(the module exists, but the name doesn't) or a deep submodule with a typo'd
+import statement.
+
+Runtime errors at import time (e.g. missing env vars, network calls) are
+intentionally ignored so this check stays focused on import validity.
+
+Usage:
+    python .github/scripts/import_smoke.py PKG [PKG ...] [--skip MOD ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import pkgutil
+import sys
+import traceback
+
+
+def main(packages: list[str], skip: set[str]) -> int:
+    failures: list[tuple[str, str, str]] = []
+    skipped: list[str] = []
+    scanned = 0
+
+    for pkg_name in packages:
+        if pkg_name in skip:
+            skipped.append(pkg_name)
+            continue
+        try:
+            pkg = importlib.import_module(pkg_name)
+        except (ImportError, ModuleNotFoundError, SyntaxError) as e:
+            failures.append((pkg_name, type(e).__name__, str(e)))
+            continue
+        except Exception as e:
+            print(
+                f"WARN  {pkg_name}: skipped — non-import error at top-level "
+                f"({type(e).__name__}: {e})"
+            )
+            continue
+
+        scanned += 1
+        if not hasattr(pkg, "__path__"):
+            continue
+
+        for modinfo in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + "."):
+            if modinfo.name in skip:
+                skipped.append(modinfo.name)
+                continue
+            try:
+                importlib.import_module(modinfo.name)
+                scanned += 1
+            except (ImportError, ModuleNotFoundError, SyntaxError) as e:
+                failures.append((modinfo.name, type(e).__name__, str(e)))
+            except Exception:
+                exc = traceback.format_exception_only(*sys.exc_info()[:2])[-1].strip()
+                print(f"WARN  {modinfo.name}: skipped — {exc}")
+                scanned += 1
+
+    if skipped:
+        print(f"SKIP  {len(skipped)} module(s) explicitly skipped: {sorted(skipped)}")
+
+    if failures:
+        print(f"\nFAIL  {len(failures)} module(s) failed to import:\n")
+        for name, etype, msg in failures:
+            print(f"  {name}")
+            print(f"    {etype}: {msg}")
+        return 1
+
+    print(f"\nOK    {scanned} module(s) imported cleanly across {packages}")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("packages", nargs="+", help="Top-level packages to scan")
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        help="Module name to skip (repeatable). Useful for orphan dev scripts with "
+        "known-stale imports that aren't worth fixing yet.",
+    )
+    args = parser.parse_args()
+    sys.exit(main(args.packages, set(args.skip)))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,21 @@ jobs:
 
             - name: Run Ruff (minimal strict)
               run: ruff check . --select=F821
+
+            # Catches broken imports that static linters miss
+            # (e.g. `from typing import BaseException` — typing has no such
+            # name, but ruff F401/F821 are happy because the symbol is bound
+            # locally by the import). Only fails on ImportError / SyntaxError;
+            # runtime/config errors at import time are reported but not fatal.
+            - name: Install uv
+              uses: astral-sh/setup-uv@v3
+
+            - name: Install package
+              run: uv sync --frozen
+
+            - name: Import smoke test
+              # `run_local` is an orphan dev script with stale example imports;
+              # not used anywhere. Drop the skip once it's cleaned up or removed.
+              run: |
+                  uv run python .github/scripts/import_smoke.py optexity \
+                      --skip optexity.inference.run_local


### PR DESCRIPTION
## Summary

Adds a CI step that recursively imports every submodule of the `optexity` package. Fails on `ImportError`, `ModuleNotFoundError`, or `SyntaxError` — catches things ruff F821/F401 can't.

## Why

`from typing import BaseException` (a real example from a recent question) — typing has no such name, but ruff F821 is happy (the symbol gets bound locally by the import) and F401 is happy if you reference it. The break only surfaces at runtime.

| Check | Catches `from typing import BaseException`? |
| --- | --- |
| ruff F821 (undefined names) | No — import binds the name |
| ruff F401 (unused imports) | No — used in annotations |
| black / isort | No — formatters only |
| **This smoke test** | **Yes** — fails on `ImportError` |

## How

- `.github/scripts/import_smoke.py` — walks all submodules of given packages via `pkgutil.walk_packages`. Fails on import-validity errors; reports runtime/config errors (missing env vars, etc.) as `WARN` so the check stays focused.
- CI step uses `uv sync --frozen` against the existing `uv.lock` for fast install (~30s).

## Pre-existing breakage uncovered

`optexity.inference.run_local` references several deleted example modules (`fadv`, `shein`, `pshpgeorgia_medicaid`, `supabase_login`). It's an orphan dev script — zero references in the codebase. Explicitly skipped via `--skip` flag for now with an inline comment in lint.yml. **Recommend cleaning it up or moving to `scratch/` in a follow-up.**

## Local verification

```
$ python .github/scripts/import_smoke.py optexity --skip optexity.inference.run_local
SKIP  1 module(s) explicitly skipped: ['optexity.inference.run_local']
OK    92 module(s) imported cleanly across ['optexity']
```

## Test plan

- [x] Local run on this branch: 92 modules import cleanly
- [ ] CI lint job green on this PR