### PR TITLE
fix(browser-restart): repair dedicated-browser health check and stale flag

### DIFF
--- a/optexity/inference/child_process.py
+++ b/optexity/inference/child_process.py
@@ -113,10 +113,20 @@ async def setup_browser(task: Task, unique_child_arn: str, child_process_id: int
         system_info.total_system_memory_used / system_info.total_system_memory > 0.6
     )
 
+    # Drain any pending restart flag first so it can't leak into a subsequent task
+    # if the global browser was already nulled out (e.g. by the outer-finally restart
+    # after WORKER_CRASHED / timeout, or by the retry path in _run_attempt).
+    restart_reason = consume_browser_restart_request(child_process_id)
+    if restart_reason and _global_actual_browser is None:
+        logger.info(
+            "Discarding stale browser restart request (browser already absent): %s",
+            restart_reason[:500],
+        )
+        restart_reason = None
+
     if _global_actual_browser is not None:
 
         restart_browser = False
-        restart_reason = consume_browser_restart_request(child_process_id)
         if restart_reason:
             logger.info(
                 "Worker requested browser restart before task: %s", restart_reason[:500]

--- a/optexity/inference/infra/actual_browser.py
+++ b/optexity/inference/infra/actual_browser.py
@@ -389,7 +389,7 @@ class ActualBrowser:
                 pages = self.context.pages
                 if not pages:
                     return False
-                await pages[0].evaluate("() => true", timeout=timeout * 1000)
+                await asyncio.wait_for(pages[0].evaluate("() => true"), timeout=timeout)
                 return True
             except Exception as e:
                 logger.debug("Browser session health check failed: %s", e)

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-12T13:18:28.576042Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1542,7 +1542,7 @@ wheels = [
 
 [[package]]
 name = "optexity"
-version = "0.1.5.79"
+version = "0.1.5.81"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Two follow-ups to #123 that together caused spurious dedicated-browser restarts in production.

1. **`Page.evaluate` does not accept a `timeout` kwarg.** `check_browser_session_healthy` in `actual_browser.py` was calling `pages[0].evaluate(\"() => true\", timeout=timeout * 1000)`. The signature is `evaluate(expression, arg=None, *, isolated_context=True)` — passing `timeout=…` raises `TypeError`, which the bare `except Exception` swallowed and turned into a `False` return. Every non-`browser-use` dedicated task failed the health check at `setup_browser` and restarted the browser (log line: \"Restarting actual browser: setup_browser health check\"). Fixed by wrapping the call in `asyncio.wait_for`, which is the correct way to bound it.

2. **Stale `/tmp/optexity_browser_restart_<id>` flag leak.** `consume_browser_restart_request` lived inside `if _global_actual_browser is not None:` in `setup_browser`. When the outer-finally restart path (`WORKER_CRASHED` / timeout) or the `_run_attempt` retry path had already nulled the global, the flag was left on disk and consumed at the *next* task's `setup_browser`, causing a spurious restart of a freshly started browser. Drain the flag at the top of `setup_browser` and discard it when the browser is already absent.

## Test plan

- [ ] Verify dedicated tasks no longer restart every run — confirm absence of \"Dedicated browser session unhealthy, restarting browser\" / \"Restarting actual browser: setup_browser health check\" in logs for healthy sessions.
- [ ] Confirm dedicated browser still restarts when expected: provoke a real `Target closed` / context-closed error mid-task; next task should pick up via the consumed flag path.
- [ ] After a `WORKER_CRASHED` exit, confirm only one restart fires (the outer-finally restart) — no spurious second restart on the task after.