### PR TITLE
Add optional 2FA fetch-window time offsets (minutes)

### DIFF
--- a/docs/docs/action-types/two-factor-auth.mdx
+++ b/docs/docs/action-types/two-factor-auth.mdx
@@ -189,6 +189,36 @@ Fetch codes from a custom API endpoint.
 | `api_call_headers` | `dict`            | Request headers         |
 | `api_call_body`    | `dict`            | Request body (for POST) |
 
+## Tuning the Fetch Window
+
+When a 2FA code is fetched, Optexity only considers messages that arrived within a time window: from when the 2FA timer started (`start_2fa_timer`) up to the timer start plus the maximum wait time. Clock skew between Optexity and the email/Slack/SMS provider can occasionally push a legitimate code just outside this window, causing it to be missed.
+
+Two optional fields let you widen the window. Both are expressed in **minutes** and default to `0`, so existing automations are unaffected.
+
+```json
+{
+    "fetch_2fa_action": {
+        "fetch_email_2fa_action": {
+            "email_address": "user@example.com",
+            "subject": "Your login verification code",
+            "service": "gmail"
+        },
+        "output_variable_name": "email_code",
+        "start_2fa_time_offset_minutes": 1,
+        "end_2fa_time_offset_minutes": 2
+    }
+}
+```
+
+### Properties
+
+| Property                        | Type    | Default | Description                                                              |
+| ------------------------------- | ------- | ------- | ------------------------------------------------------------------------ |
+| `start_2fa_time_offset_minutes` | `float` | `0`     | Minutes **subtracted** from the window start, to look further back.      |
+| `end_2fa_time_offset_minutes`   | `float` | `0`     | Minutes **added** to the window end, to look further forward.            |
+
+With the example above, the fetch window becomes `[timer start − 1 min, timer start + max wait + 2 min]`. Use small values (1–2 minutes) — they exist to absorb clock skew and slightly late delivery, not to replace the maximum wait time, which still governs how long Optexity keeps polling.
+
 ## Using the 2FA Code
 
 After fetching, the code is available in `generated_parameters` under the specified `output_variable_name`:

--- a/optexity/inference/core/run_two_fa.py
+++ b/optexity/inference/core/run_two_fa.py
@@ -51,7 +51,12 @@ async def run_two_fa_action(two_fa_action: TwoFAAction, memory: Memory, task: Ta
 
     while elapsed < two_fa_action.max_wait_time:
         messages = await fetch_messages(
-            two_fa_action.action, memory, two_fa_action.max_wait_time, task
+            two_fa_action.action,
+            memory,
+            two_fa_action.max_wait_time,
+            task,
+            two_fa_action.start_2fa_time_offset_minutes,
+            two_fa_action.end_2fa_time_offset_minutes,
         )
         if messages and len(messages) > 0:
             final_prompt, response, token_usage = _get_two_fa_agent(task).extract_code(
@@ -98,11 +103,16 @@ async def fetch_messages(
     memory: Memory,
     max_wait_time: float,
     task: Task,
+    start_2fa_time_offset_minutes: float = 0.0,
+    end_2fa_time_offset_minutes: float = 0.0,
 ):
 
-    start_2fa_time = memory.automation_state.start_2fa_time
-    end_2fa_time = memory.automation_state.start_2fa_time + timedelta(
-        seconds=max_wait_time
+    base_2fa_time = memory.automation_state.start_2fa_time
+    start_2fa_time = base_2fa_time - timedelta(minutes=start_2fa_time_offset_minutes)
+    end_2fa_time = (
+        base_2fa_time
+        + timedelta(seconds=max_wait_time)
+        + timedelta(minutes=end_2fa_time_offset_minutes)
     )
 
     headers = {"x-api-key": task.api_key}

--- a/optexity/schema/actions/two_fa_action.py
+++ b/optexity/schema/actions/two_fa_action.py
@@ -62,6 +62,8 @@ class TwoFAAction(BaseModel):
     output_variable_name: str
     max_wait_time: float = 300.0
     check_interval: float = 30.0
+    start_2fa_time_offset_minutes: float = 0.0
+    end_2fa_time_offset_minutes: float = 0.0
 
     def replace(self, pattern: str, replacement: str):
         if self.instructions:


### PR DESCRIPTION
Add start_2fa_time_offset_minutes and end_2fa_time_offset_minutes to TwoFAAction (both default 0.0, fully backward-compatible). The start offset is subtracted from and the end offset added to the 2FA message fetch window, widening it to tolerate clock skew between us and the email/Slack/SMS provider.