### PR TITLE
feat(axtree): strict -1 + agentic fallback for unconfident locator

### DIFF
--- a/optexity/inference/agents/index_prediction/action_prediction_locator_axtree.py
+++ b/optexity/inference/agents/index_prediction/action_prediction_locator_axtree.py
@@ -14,8 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 class IndexPredictionOutputAllowNegative(BaseModel):
+    reasoning: str = Field(
+        description="Brief reasoning: the specific element the goal targets, whether the axtree contains an element whose own text/label/role clearly matches it, and why you chose this index (or -1)."
+    )
+    matched_element_text: str = Field(
+        description='The visible text, label, or role of the element you selected, copied verbatim from the axtree. Set to "" when returning -1 because no element matches.'
+    )
     index: int = Field(
-        description="The index of the interactive element in the axtree that would achieve the desired outcome. It is either a positive integer or -1 if the element is not found in the axtree."
+        description="The index of the interactive element in the axtree that would achieve the desired outcome. It is either a positive integer or -1 if no element in the axtree clearly matches the goal."
     )
 
 

--- a/optexity/inference/agents/index_prediction/prompt.py
+++ b/optexity/inference/agents/index_prediction/prompt.py
@@ -14,5 +14,9 @@ Your output must be a single numerical index from the axtree if the element foun
 """
 
 can_return_negative_index_prompt = """
-If the element found in the axtree is not the same as the element in the goal, you should return `-1`. For example, if the goal is to click on the "Continue" button, and the axtree does not contain a button with the text "Continue" or "Next", you should return `-1`. But if the goal is to click on the "Login" button, and the axtree contains a button with the text "Get Started" instead of "Login" because the website changed slightly, you should return the index of the "Get Started" button. But do not output any index if the element in the axtree is not matching the goal, just return `-1`, this is most likely because we are on the wrong page to fulfill our goal.
+Return `-1` whenever you have **ANY doubt** that the element you picked is the correct one for the goal. Only return a positive index when you are clearly confident that an element in the axtree corresponds to the element described in the goal.
+
+Do not guess and do not settle for an element that is merely "close enough". If the goal asks for a specific control (e.g. a "Continue" button) and the axtree does not contain an element that clearly matches it, return `-1`. Partial matches, ambiguous candidates, or uncertainty about whether you are even on the correct page should all result in `-1`.
+
+Returning `-1` is safe: it triggers a dedicated fallback that will accomplish the step another way. Returning a wrong positive index is harmful, because it makes the automation interact with the wrong element. When in doubt, return `-1`.
 """

--- a/optexity/inference/agents/index_prediction/prompt.py
+++ b/optexity/inference/agents/index_prediction/prompt.py
@@ -10,13 +10,25 @@ Your core responsibility is to translate a user's intended action, described thr
 
 **Crucial Task Directives:**
 
-Your output must be a single numerical index from the axtree if the element found in the axtree is the same as the element in the goal. This is because index-based interaction is more reliable than trying to replicate a playwright command, which can fail if the element isn't precisely found.
+You identify the interactive element by its numerical index in the axtree — the element that matches the one described in the goal. Index-based interaction is more reliable than replicating a playwright command, which can fail if the element isn't precisely found.
 """
 
 can_return_negative_index_prompt = """
-Return `-1` whenever you have **ANY doubt** that the element you picked is the correct one for the goal. Only return a positive index when you are clearly confident that an element in the axtree corresponds to the element described in the goal.
+Verify the match before you answer. Do not pick an element just because it is the closest available, or because it shares keywords with the goal text.
 
-Do not guess and do not settle for an element that is merely "close enough". If the goal asks for a specific control (e.g. a "Continue" button) and the axtree does not contain an element that clearly matches it, return `-1`. Partial matches, ambiguous candidates, or uncertainty about whether you are even on the correct page should all result in `-1`.
+Work through this:
 
-Returning `-1` is safe: it triggers a dedicated fallback that will accomplish the step another way. Returning a wrong positive index is harmful, because it makes the automation interact with the wrong element. When in doubt, return `-1`.
+1. **Identify the target.** From the goal, determine the specific element to act on — its kind and its identity (e.g. a result link whose text is the company name, a "Continue" button, a specific menu item).
+2. **Find the matching element.** Look for the axtree element whose **own** visible text / label / role matches that target. Match on the element's own identity, NOT on keyword overlap with the goal sentence. A goal that mentions "search results" does **not** mean the search input box; an element that merely sits near the target is **not** the target.
+3. **Decide:**
+   - If one element **clearly** matches the target, return its index. You do not need to be 100% certain — minor uncertainty about an element that clearly matches is fine; return it.
+   - If **no** element clearly matches, return `-1`. In particular, return `-1` when:
+       * the goal names a specific entity or label and no element's text corresponds to it,
+       * only related or adjacent controls are present (e.g. a search box when a search **result** is wanted), not the target itself,
+       * the page is not the kind the goal expects (e.g. the goal wants a search result but this is a blog/listing page),
+       * the best you can find is only a partial or ambiguous match.
+
+A wrong positive index is harmful — it makes the automation act on the wrong element. `-1` is safe — it routes the step to a dedicated fallback. So when no element clearly corresponds to the target, prefer `-1` over a "close enough" guess. But do **not** return `-1` merely because you feel slightly unsure about an element that clearly matches — that needlessly diverts a recoverable step.
+
+Fill in `reasoning` and `matched_element_text` **before** `index`: name the target, quote the verbatim text/label of the element you matched, and explain the choice. When returning `-1`, set `matched_element_text` to "" and use `reasoning` to say what was missing.
 """

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -123,8 +123,27 @@ def _flatten_action_nodes(nodes, out: list) -> None:
             _flatten_action_nodes(node.else_nodes, out)
 
 
+def _describe_node_for_window(node: ActionNode) -> str:
+    """Value-bearing description of a node for the workflow window.
+
+    Reuses the goal builder (which splices in input/select values) so the agent
+    can verify a previous step actually took effect, falling back to a short
+    summary for non-interaction nodes.
+    """
+    ia = node.interaction_action
+    if ia is not None:
+        desc = _describe_goal(ia, "")
+        if desc and desc.strip():
+            return desc
+    return _summarize_action_node(node) or "step"
+
+
 def _build_workflow_window(task: Task, interaction_action: InteractionAction) -> str:
     """Build a small window (prev + current + next steps) around the failing step.
+
+    Previous steps are rendered with their full value-bearing goals so the agent
+    can check whether each already-run prerequisite actually landed on the page.
+    The current step is marked; next steps are kept as light context only.
 
     The current step is located by object identity of its interaction_action.
     This resolves for top-level nodes; loop-expanded nodes are deep-copied at
@@ -147,9 +166,15 @@ def _build_workflow_window(task: Task, interaction_action: InteractionAction) ->
         end = min(len(flat), current_idx + WINDOW_RADIUS + 1)
         lines = []
         for i in range(start, end):
-            summary = _summarize_action_node(flat[i]) or "step"
-            marker = "  >> CURRENT >> " if i == current_idx else "                "
-            lines.append(f"{marker}step {i}: {summary}")
+            if i < current_idx:
+                desc = _describe_node_for_window(flat[i])
+                lines.append(f"  [already ran] step {i}: {desc}")
+            elif i == current_idx:
+                desc = _describe_node_for_window(flat[i])
+                lines.append(f"  >> CURRENT (failed locator) >> step {i}: {desc}")
+            else:
+                summary = _summarize_action_node(flat[i]) or "step"
+                lines.append(f"  [do NOT do — context only] step {i}: {summary}")
         return "\n".join(lines)
     except Exception as e:
         logger.error(f"Failed to build workflow window for agentic fallback: {e}")

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -2,6 +2,8 @@ import logging
 from functools import lru_cache
 from importlib import resources
 
+import aiofiles
+
 from optexity.exceptions import ElementNotFoundInAxtreeException
 from optexity.inference.core.interaction.handle_agentic_task import handle_agentic_task
 from optexity.inference.infra.browser import Browser
@@ -16,6 +18,9 @@ logger = logging.getLogger(__name__)
 FALLBACK_MAX_STEPS = 12
 # How many steps before/after the current one to include for workflow context.
 WINDOW_RADIUS = 2
+# How much of the run log (optexity.log, the same file we ship to S3) to feed the
+# agent. We tail it so a long run doesn't blow up the prompt; bump if needed.
+FALLBACK_LOG_TAIL_CHARS = 20000
 
 
 @lru_cache(maxsize=1)
@@ -181,6 +186,34 @@ def _build_workflow_window(task: Task, interaction_action: InteractionAction) ->
         return "(surrounding workflow steps unavailable)"
 
 
+async def _read_run_log_tail(task: Task) -> str:
+    """Read the tail of the task's runtime log (optexity.log).
+
+    This is the same log we persist to S3; the recent lines capture what the
+    deterministic run was doing right up to the -1 failure, which is the most
+    useful debugging context for the fallback agent.
+    """
+    try:
+        async with aiofiles.open(
+            task.log_file_path, "r", encoding="utf-8", errors="replace"
+        ) as f:
+            content = await f.read()
+    except FileNotFoundError:
+        return "(run log not available)"
+    except Exception as e:
+        logger.error(f"Failed to read run log for agentic fallback: {e}")
+        return "(run log not available)"
+
+    if not content:
+        return "(run log empty)"
+    if len(content) > FALLBACK_LOG_TAIL_CHARS:
+        return (
+            f"...(truncated; showing last {FALLBACK_LOG_TAIL_CHARS} chars)...\n"
+            + content[-FALLBACK_LOG_TAIL_CHARS:]
+        )
+    return content
+
+
 async def run_axtree_fallback_agent(
     interaction_action: InteractionAction,
     error: ElementNotFoundInAxtreeException,
@@ -200,6 +233,9 @@ async def run_axtree_fallback_agent(
     error_logs = str(error.message)
     if getattr(error, "original_error", None) is not None:
         error_logs += f"\nUnderlying error: {error.original_error}"
+
+    run_log = await _read_run_log_tail(task)
+    error_logs += f"\n\n--- Recent run log (optexity.log) ---\n{run_log}"
 
     try:
         current_url = await browser.get_current_page_url() or "(unknown)"

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -13,7 +13,7 @@ from optexity.schema.task import Task
 logger = logging.getLogger(__name__)
 
 # Guardrails for the fallback agent: keep it short and scoped to a single step.
-FALLBACK_MAX_STEPS = 8
+FALLBACK_MAX_STEPS = 12
 # How many steps before/after the current one to include for workflow context.
 WINDOW_RADIUS = 2
 

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -1,0 +1,204 @@
+import logging
+from functools import lru_cache
+from importlib import resources
+
+from optexity.exceptions import ElementNotFoundInAxtreeException
+from optexity.inference.core.interaction.handle_agentic_task import handle_agentic_task
+from optexity.inference.infra.browser import Browser
+from optexity.schema.actions.interaction_action import AgenticTask, InteractionAction
+from optexity.schema.automation import ActionNode, ForLoopNode, IfElseNode
+from optexity.schema.memory import Memory
+from optexity.schema.task import Task
+
+logger = logging.getLogger(__name__)
+
+# Guardrails for the fallback agent: keep it short and scoped to a single step.
+FALLBACK_MAX_STEPS = 8
+# How many steps before/after the current one to include for workflow context.
+WINDOW_RADIUS = 2
+
+
+@lru_cache(maxsize=1)
+def _load_fallback_prompt_template() -> str:
+    return (
+        resources.files("optexity.prompts")
+        .joinpath("agentic_fallback.md")
+        .read_text(encoding="utf-8")
+    )
+
+
+def _summarize_action_node(node: ActionNode) -> str | None:
+    """Return a short human-readable summary of an action node for context."""
+    ia = node.interaction_action
+    if ia is not None:
+        for name in [
+            "click_element",
+            "input_text",
+            "select_option",
+            "check",
+            "uncheck",
+            "hover",
+            "upload_file",
+            "key_press",
+            "scroll",
+            "go_to_url",
+            "download_url_as_pdf",
+            "go_back",
+        ]:
+            sub = getattr(ia, name, None)
+            if sub is not None:
+                desc = (
+                    getattr(sub, "prompt_instructions", "")
+                    or getattr(sub, "command", "")
+                    or getattr(sub, "url", "")
+                    or ""
+                )
+                label = name.replace("_", " ")
+                return f"{label}: {desc}".strip().rstrip(":").strip()
+        return "interaction action"
+    if node.extraction_action is not None:
+        return "extract data"
+    if node.assertion_action is not None:
+        return "assertion check"
+    if node.captcha_action is not None:
+        return "solve captcha"
+    if node.human_in_loop_action is not None:
+        return "human-in-loop step"
+    if node.python_script_action is not None:
+        return "python script"
+    if node.sleep_action is not None:
+        return "wait"
+    return None
+
+
+def _describe_goal(interaction_action: InteractionAction, fallback_command: str) -> str:
+    """Build a complete, self-contained goal for the fallback agent.
+
+    error.command only carries the locator description (prompt_instructions). For
+    input/select steps the *value* to enter lives in a separate field, so we must
+    splice it in or the agent won't know what to type/select.
+    """
+    ia = interaction_action
+
+    if ia.click_element is not None:
+        base = ia.click_element.prompt_instructions or fallback_command
+        return f"Click: {base}"
+    if ia.input_text is not None:
+        base = ia.input_text.prompt_instructions or fallback_command
+        value = ia.input_text.input_text
+        if value:
+            return f'Type the value "{value}" into: {base}'
+        return f"Type into: {base}"
+    if ia.select_option is not None:
+        base = ia.select_option.prompt_instructions or fallback_command
+        values = ia.select_option.select_values
+        if values:
+            return f"Select option(s) {values} in: {base}"
+        return f"Select an option in: {base}"
+    if ia.check is not None:
+        return f"Check (tick) the checkbox: {ia.check.prompt_instructions or fallback_command}"
+    if ia.uncheck is not None:
+        return f"Uncheck the checkbox: {ia.uncheck.prompt_instructions or fallback_command}"
+    if ia.hover is not None:
+        return f"Hover over: {ia.hover.prompt_instructions or fallback_command}"
+    if ia.upload_file is not None:
+        return f"Upload a file to: {ia.upload_file.prompt_instructions or fallback_command}"
+
+    return fallback_command
+
+
+def _flatten_action_nodes(nodes, out: list) -> None:
+    """Statically flatten the automation tree into a linear list of ActionNodes.
+
+    Both branches of if/else and the body of for-loops are included so the agent
+    sees the surrounding intent regardless of runtime branching.
+    """
+    for node in nodes:
+        if isinstance(node, ActionNode):
+            out.append(node)
+        elif isinstance(node, ForLoopNode):
+            _flatten_action_nodes(node.nodes, out)
+        elif isinstance(node, IfElseNode):
+            _flatten_action_nodes(node.if_nodes, out)
+            _flatten_action_nodes(node.else_nodes, out)
+
+
+def _build_workflow_window(task: Task, interaction_action: InteractionAction) -> str:
+    """Build a small window (prev + current + next steps) around the failing step.
+
+    The current step is located by object identity of its interaction_action.
+    This resolves for top-level nodes; loop-expanded nodes are deep-copied at
+    runtime and won't match, in which case we degrade gracefully.
+    """
+    try:
+        flat: list[ActionNode] = []
+        _flatten_action_nodes(task.automation.nodes, flat)
+
+        current_idx = None
+        for i, node in enumerate(flat):
+            if node.interaction_action is interaction_action:
+                current_idx = i
+                break
+
+        if current_idx is None:
+            return "(surrounding workflow steps unavailable)"
+
+        start = max(0, current_idx - WINDOW_RADIUS)
+        end = min(len(flat), current_idx + WINDOW_RADIUS + 1)
+        lines = []
+        for i in range(start, end):
+            summary = _summarize_action_node(flat[i]) or "step"
+            marker = "  >> CURRENT >> " if i == current_idx else "                "
+            lines.append(f"{marker}step {i}: {summary}")
+        return "\n".join(lines)
+    except Exception as e:
+        logger.error(f"Failed to build workflow window for agentic fallback: {e}")
+        return "(surrounding workflow steps unavailable)"
+
+
+async def run_axtree_fallback_agent(
+    interaction_action: InteractionAction,
+    error: ElementNotFoundInAxtreeException,
+    task: Task,
+    memory: Memory,
+    browser: Browser,
+):
+    """Hand a single failed (axtree -1) step to a general browser_use agent.
+
+    The agent is given the step goal, a window of surrounding workflow steps, and
+    the failure logs, then asked to accomplish only this step (dismissing any
+    popup/interstitial that gets in the way).
+    """
+    goal = _describe_goal(interaction_action, error.command or "(no goal provided)")
+    workflow_window = _build_workflow_window(task, interaction_action)
+
+    error_logs = str(error.message)
+    if getattr(error, "original_error", None) is not None:
+        error_logs += f"\nUnderlying error: {error.original_error}"
+
+    try:
+        current_url = await browser.get_current_page_url() or "(unknown)"
+    except Exception:
+        current_url = "(unknown)"
+
+    prompt = (
+        _load_fallback_prompt_template()
+        .replace("<<GOAL>>", str(goal))
+        .replace("<<WORKFLOW_WINDOW>>", workflow_window)
+        .replace("<<ERROR_LOGS>>", error_logs)
+        .replace("<<CURRENT_URL>>", str(current_url))
+    )
+
+    fallback_action = AgenticTask(
+        task=prompt,
+        max_steps=FALLBACK_MAX_STEPS,
+        backend="browser_use",
+        use_vision=True,
+        keep_alive=True,
+    )
+
+    logger.debug(
+        f"Running agentic fallback for goal '{goal}' on {current_url} "
+        f"(max_steps={FALLBACK_MAX_STEPS})"
+    )
+    return await handle_agentic_task(fallback_action, task, memory, browser)

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -21,8 +21,6 @@ WINDOW_RADIUS = 2
 # How much of the run log (optexity.log, the same file we ship to S3) to feed the
 # agent. We tail it so a long run doesn't blow up the prompt; bump if needed.
 FALLBACK_LOG_TAIL_CHARS = 20000
-# Cap a single input-parameter value so a large blob doesn't blow up the prompt.
-INPUT_PARAM_MAX_VALUE_CHARS = 500
 
 
 @lru_cache(maxsize=1)
@@ -230,10 +228,7 @@ def _render_input_parameters(task: Task) -> str:
         if not isinstance(values, list):
             continue
         for i, value in enumerate(values):
-            s = str(value)
-            if len(s) > INPUT_PARAM_MAX_VALUE_CHARS:
-                s = s[:INPUT_PARAM_MAX_VALUE_CHARS] + "…(truncated)"
-            lines.append(f'  - {{{key}[{i}]}} = "{s}"')
+            lines.append(f'  - {{{key}[{i}]}} = "{value}"')
     return "\n".join(lines) if lines else "(no input parameters provided)"
 
 

--- a/optexity/inference/core/interaction/agentic_fallback.py
+++ b/optexity/inference/core/interaction/agentic_fallback.py
@@ -21,6 +21,8 @@ WINDOW_RADIUS = 2
 # How much of the run log (optexity.log, the same file we ship to S3) to feed the
 # agent. We tail it so a long run doesn't blow up the prompt; bump if needed.
 FALLBACK_LOG_TAIL_CHARS = 20000
+# Cap a single input-parameter value so a large blob doesn't blow up the prompt.
+INPUT_PARAM_MAX_VALUE_CHARS = 500
 
 
 @lru_cache(maxsize=1)
@@ -214,6 +216,27 @@ async def _read_run_log_tail(task: Task) -> str:
     return content
 
 
+def _render_input_parameters(task: Task) -> str:
+    """Render the automation's (non-secret) input parameters for the agent.
+
+    Shown in ``{key[index]} = "value"`` form so the agent can map a step's
+    placeholder to its real value and fill an empty/missing field. Only
+    ``input_parameters`` are exposed — ``secure_parameters`` (which resolve to
+    real secrets) are deliberately never sent to the fallback agent.
+    """
+    params = task.input_parameters or {}
+    lines: list[str] = []
+    for key, values in params.items():
+        if not isinstance(values, list):
+            continue
+        for i, value in enumerate(values):
+            s = str(value)
+            if len(s) > INPUT_PARAM_MAX_VALUE_CHARS:
+                s = s[:INPUT_PARAM_MAX_VALUE_CHARS] + "…(truncated)"
+            lines.append(f'  - {{{key}[{i}]}} = "{s}"')
+    return "\n".join(lines) if lines else "(no input parameters provided)"
+
+
 async def run_axtree_fallback_agent(
     interaction_action: InteractionAction,
     error: ElementNotFoundInAxtreeException,
@@ -246,6 +269,7 @@ async def run_axtree_fallback_agent(
         _load_fallback_prompt_template()
         .replace("<<GOAL>>", str(goal))
         .replace("<<WORKFLOW_WINDOW>>", workflow_window)
+        .replace("<<INPUT_PARAMETERS>>", _render_input_parameters(task))
         .replace("<<ERROR_LOGS>>", error_logs)
         .replace("<<CURRENT_URL>>", str(current_url))
     )

--- a/optexity/inference/core/interaction/handle_agentic_task.py
+++ b/optexity/inference/core/interaction/handle_agentic_task.py
@@ -67,7 +67,7 @@ async def handle_agentic_task(
         logger.debug(f"Starting browser session for agentic task {browser.cdp_url} ")
         await agent.browser_session.start()
         logger.debug(f"Finally running agentic task on browser_use {browser.cdp_url} ")
-        await agent.run(max_steps=agentic_task_action.max_steps)
+        history = await agent.run(max_steps=agentic_task_action.max_steps)
         logger.debug(f"Agentic task completed on browser_use {browser.cdp_url} ")
 
         agent.stop()
@@ -75,5 +75,9 @@ async def handle_agentic_task(
             await agent.browser_session.stop()
             await agent.browser_session.reset()
 
+        return history
+
     elif agentic_task_action.backend == "browserbase":
         raise NotImplementedError("Browserbase is not supported yet")
+
+    return None

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -565,11 +565,18 @@ async def get_index_from_prompt(
         memory.browser_states[-1].final_prompt = final_prompt
         memory.browser_states[-1].llm_response = response.model_dump()
 
-        if response.index == -1:
+        # Treat any non-positive index as "not found". -1 is the documented
+        # not-found sentinel, but the model sometimes emits 0 (or another <= 0
+        # value) to mean "no match". browser_use's ActionModel requires
+        # index >= 1, so without this guard a non-positive index crashes the
+        # click (AxtreeIndexActionFailedException) instead of cleanly routing to
+        # the agentic fallback the way -1 does.
+        if response.index <= 0:
             raise ElementNotFoundInAxtreeException(
                 message=f"Element not found in the axtree: {prompt_instructions}",
                 original_error=Exception(
-                    f"Element not found in the axtree: {prompt_instructions}"
+                    f"Index predictor returned non-positive index "
+                    f"{response.index} for: {prompt_instructions}"
                 ),
                 command=prompt_instructions,
             )

--- a/optexity/inference/core/run_interaction.py
+++ b/optexity/inference/core/run_interaction.py
@@ -9,6 +9,9 @@ from optexity.exceptions import (
     ElementNotFoundInAxtreeException,
 )
 from optexity.inference.agents.error_handler.error_handler import ErrorHandlerAgent
+from optexity.inference.core.interaction.agentic_fallback import (
+    run_axtree_fallback_agent,
+)
 from optexity.inference.core.interaction.handle_agentic_task import handle_agentic_task
 from optexity.inference.core.interaction.handle_check import (
     handle_check_element,
@@ -158,7 +161,11 @@ async def run_interaction_action(
             await handle_key_press(interaction_action.key_press, memory, browser)
         elif interaction_action.scroll:
             await handle_scroll(interaction_action.scroll, memory, browser)
-    except (AssertLocatorPresenceException, ElementNotFoundInAxtreeException) as e:
+    except ElementNotFoundInAxtreeException as e:
+        await handle_element_not_found_in_axtree(
+            e, interaction_action, task, memory, browser
+        )
+    except AssertLocatorPresenceException as e:
         await handle_assert_locator_presence_error(
             e, interaction_action, task, memory, browser, retries_left
         )
@@ -266,6 +273,67 @@ async def handle_download_url_as_pdf(
         await f.write(content)
 
     memory.downloads.append(download_path)
+
+
+async def handle_element_not_found_in_axtree(
+    error: ElementNotFoundInAxtreeException,
+    interaction_action: InteractionAction,
+    task: Task,
+    memory: Memory,
+    browser: Browser,
+):
+    """Axtree locator returned -1 (not confident). Hand this single step to a
+    general agentic fallback, then treat the node as completed.
+
+    The deterministic locator is intentionally strict (any doubt -> -1), so a -1
+    means "let the agent figure this step out" rather than "fail". We do not
+    re-predict afterwards: once the agent stops, the node is considered done.
+    """
+    logger.warning(
+        f"Element not found in axtree (-1) for goal '{error.command}' at node "
+        f"{memory.automation_state.step_index}; running agentic fallback."
+    )
+    try:
+        history = await run_axtree_fallback_agent(
+            interaction_action, error, task, memory, browser
+        )
+    except Exception as agent_error:
+        # The agent infrastructure itself failed (not just "couldn't do it").
+        # Surface the original failure rather than silently skipping the step.
+        logger.error(
+            f"Agentic fallback crashed for node {memory.automation_state.step_index}: "
+            f"{agent_error}"
+        )
+        raise error
+
+    # The agent ran. Distinguish "did the step" from "gave up after max_steps":
+    # agent.run() does NOT raise when it simply fails to accomplish the task, so
+    # without this check a failed step would be silently marked completed.
+    step_index = memory.automation_state.step_index
+    succeeded = None
+    try:
+        succeeded = history.is_successful() if history is not None else None
+    except Exception as e:
+        logger.error(
+            f"Could not read agentic fallback result for node {step_index}: {e}"
+        )
+
+    if succeeded is True:
+        logger.info(
+            f"Agentic fallback succeeded for node {step_index}; marking node completed."
+        )
+        return
+
+    # Per design we still continue (resilience), but the failure must be visible
+    # rather than silently swallowed.
+    reason = f"Agentic fallback did not confirm success for goal '{error.command}'"
+    logger.warning(
+        f"{reason} at node {step_index} (is_successful={succeeded}); "
+        f"continuing to next node anyway."
+    )
+    memory.variables.output_data.append(
+        OutputData(unique_identifier="agentic_fallback_unconfirmed", text=reason)
+    )
 
 
 async def handle_assert_locator_presence_error(

--- a/optexity/inference/core/run_interaction.py
+++ b/optexity/inference/core/run_interaction.py
@@ -283,11 +283,13 @@ async def handle_element_not_found_in_axtree(
     browser: Browser,
 ):
     """Axtree locator returned -1 (not confident). Hand this single step to a
-    general agentic fallback, then treat the node as completed.
+    general agentic fallback.
 
     The deterministic locator is intentionally strict (any doubt -> -1), so a -1
-    means "let the agent figure this step out" rather than "fail". We do not
-    re-predict afterwards: once the agent stops, the node is considered done.
+    means "let the agent figure this step out" rather than "fail". We hard-fail
+    the automation only when the agent explicitly reports it could not perform
+    the step (is_successful() is False). If the agent succeeds, or simply does
+    not flag a result (None), we treat the node as completed and continue.
     """
     logger.warning(
         f"Element not found in axtree (-1) for goal '{error.command}' at node "
@@ -318,14 +320,24 @@ async def handle_element_not_found_in_axtree(
             f"Could not read agentic fallback result for node {step_index}: {e}"
         )
 
+    if succeeded is False:
+        # The agent explicitly reported it could not perform the step. Record a
+        # breadcrumb, then hard-fail rather than advancing past an unperformed step.
+        reason = f"Agentic fallback reported failure for goal '{error.command}'"
+        logger.error(f"{reason} at node {step_index}; failing automation.")
+        memory.variables.output_data.append(
+            OutputData(unique_identifier="agentic_fallback_failed", text=reason)
+        )
+        raise Exception(f"{reason} at node {step_index}.") from error
+
     if succeeded is True:
         logger.info(
             f"Agentic fallback succeeded for node {step_index}; marking node completed."
         )
         return
 
-    # Per design we still continue (resilience), but the failure must be visible
-    # rather than silently swallowed.
+    # succeeded is None: the agent ran but did not flag a result. Continue, but
+    # leave a breadcrumb so the unconfirmed step is visible rather than silent.
     reason = f"Agentic fallback did not confirm success for goal '{error.command}'"
     logger.warning(
         f"{reason} at node {step_index} (is_successful={succeeded}); "
@@ -337,19 +349,16 @@ async def handle_element_not_found_in_axtree(
 
 
 async def handle_assert_locator_presence_error(
-    error: AssertLocatorPresenceException | ElementNotFoundInAxtreeException,
+    error: AssertLocatorPresenceException,
     interaction_action: InteractionAction,
     task: Task,
     memory: Memory,
     browser: Browser,
     retries_left: int,
 ):
-    error_type = (
-        "assert_locator_presence"
-        if isinstance(error, AssertLocatorPresenceException)
-        else "element_not_found_in_axtree_exception"
-    )
-    logger.debug(f"Handling {error_type} error: {error.command}")
+    # ElementNotFoundInAxtreeException (the -1 case) is routed to the agentic
+    # fallback, so only assert-locator-presence failures reach the classifier here.
+    logger.debug(f"Handling assert_locator_presence error: {error.command}")
     if retries_left > 1:
         browser_state_summary = await fetch_browser_state_for_classifier(
             browser, memory, task

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -1,0 +1,70 @@
+# Agentic Fallback — Complete One Automation Step
+
+You are an autonomous browser agent invoked as a **fallback** inside a larger,
+deterministic web automation. The deterministic step locator was **not confident**
+about which element to interact with (it returned `-1`), so you have been handed
+this single step to complete on the live page.
+
+There is **no human** available. Act, then stop.
+
+---
+
+## Context
+
+**Current page URL:** <<CURRENT_URL>>
+
+**Step you must complete (the goal):**
+<<GOAL>>
+
+**Where this step sits in the overall workflow** (so you understand intent and
+direction — what came before and what comes next):
+<<WORKFLOW_WINDOW>>
+
+**Why the deterministic locator failed (error logs):**
+<<ERROR_LOGS>>
+
+---
+
+## Instructions — follow in priority order (highest first)
+
+### 1. PRIMARY GOAL (MUST)
+
+Perform **exactly** the action described in the goal above — nothing more, nothing
+less. Do not perform the previous or next steps; they are shown only for context so
+you understand what this step is meant to achieve. Once this single step's action is
+done, you are finished.
+
+### 2. STAY IN THE FLOW (MUST)
+
+Stay on the current page and within the current task flow. **Do not navigate away**,
+open unrelated pages, log out, or submit forms unless completing this exact step
+genuinely requires it. You must not derail the larger automation.
+
+### 3. CLEAR OBSTRUCTIONS (SHOULD)
+
+If a popup, modal, cookie/consent banner, interstitial, "are you sure" prompt, or any
+unexpected page is **blocking** the goal, dismiss or skip it so you can proceed:
+
+- For cookie/consent prompts, **accept** ("Accept", "Agree", "Allow all", "Got it").
+- For other overlays, dismiss them ("Close", "X", "No thanks", "Skip", "Continue").
+- Do not sign up, subscribe, or follow links that leave the page.
+  Treat clearing the obstruction as a means to the goal — then complete the goal.
+
+### 4. SEARCH / FILTER HEURISTIC (WHEN APPLICABLE)
+
+If this step involves **searching or filtering** (typing into a search box, filter, or
+query field):
+
+- Prefer a **partial query** — a short, distinctive substring of the intended value —
+  rather than the full string. Full exact-match searches frequently return **no
+  results** due to formatting differences (extra spaces, middle names, punctuation,
+  IDs vs. names).
+- After the partial search returns results, **select the result that matches the full
+  intended value**, not just the first row. Picking the wrong record is worse than not
+  finding one.
+
+### 5. STOP CONDITION (MUST)
+
+As soon as the goal's action has been performed, **stop acting**. Do not keep
+clicking, do not proceed to later steps, do not "tidy up" the page. Report what you
+did and finish.

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -16,8 +16,10 @@ There is **no human** available. Act, then stop.
 **Step you must complete (the goal):**
 <<GOAL>>
 
-**Where this step sits in the overall workflow** (so you understand intent and
-direction — what came before and what comes next):
+**Where this step sits in the overall workflow.** Steps marked `[already ran]` were
+performed _before_ you were invoked and are shown with the exact values they used, so
+you can check they took effect. The `>> CURRENT <<` step is the one you must complete.
+Steps marked `[do NOT do — context only]` come after and are shown only for direction:
 <<WORKFLOW_WINDOW>>
 
 **Why the deterministic locator failed (error logs):**
@@ -27,12 +29,32 @@ direction — what came before and what comes next):
 
 ## Instructions — follow in priority order (highest first)
 
-### 1. PRIMARY GOAL (MUST)
+### 1. VERIFY PREREQUISITES, THEN COMPLETE THE CURRENT STEP (MUST)
 
-Perform **exactly** the action described in the goal above — nothing more, nothing
-less. Do not perform the previous or next steps; they are shown only for context so
-you understand what this step is meant to achieve. Once this single step's action is
-done, you are finished.
+Your job is to complete the `>> CURRENT <<` step. The locator often fails because an
+earlier `[already ran]` step did **not** actually take effect, leaving the page in the
+wrong state.
+
+First, look at the page and check whether the `[already ran]` prerequisites are
+reflected in the current state (e.g. a field that should already hold a value, a menu
+that should be open, a tab that should be selected, a page you should already be on).
+
+- If a prerequisite clearly **did not land** and is blocking the current step, perform
+  it yourself using the exact value shown — then complete the current step.
+- If the prerequisites are already satisfied, go straight to the current step.
+
+Perform **exactly** the current step's action and the minimum prerequisite repair
+needed to make it possible — nothing more. Do **not** perform any `[do NOT do]` step.
+Once the current step's action is done, you are finished.
+
+### 1a. SAFE-TO-REPEAT GUARD (MUST)
+
+Only repeat a previous step if it is **safe to repeat**. Safe: navigating to a URL,
+opening a menu/dropdown, selecting an option, typing into a field that is currently
+**empty**. **Never** repeat an action that could duplicate or re-trigger an effect:
+overwrite a field that already contains the intended value. When in
+doubt about whether a prior step already happened, assume it did and do **not** repeat
+it.
 
 ### 2. STAY IN THE FLOW (MUST)
 

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -53,9 +53,9 @@ value that isn't provided.
 1. **Observe.** Look at the current screen. Where is the goal's target — present,
    hidden, covered, not yet loaded, or genuinely absent?
 2. **Diagnose.** Compare the page against the `[already ran]` steps. Did each
-   prerequisite actually take effect? Is something blocking the target? Is a field
-   empty that should hold a value? Or has a prior action produced a valid negative
-   result (an error, a rejection, no matches)?
+   prerequisite actually achieve what it was meant to — not just run, but leave the
+   page in the state this step needs? Is something blocking the target? Or has a prior
+   action produced a valid negative result (an error, a rejection, no matches)?
 3. **Classify** the situation as exactly one of:
     - **Recoverable** — an incidental obstacle is in the way and the goal is
       achievable once it's cleared.
@@ -76,9 +76,10 @@ Signs a failure is recoverable:
 
 - a popup / modal / cookie-or-consent banner / interstitial is covering the target,
 - the element simply hasn't finished loading,
-- a required field is **empty** and you have its value in the input parameters,
-- a prerequisite step visibly did **not** take effect (a menu that should be open is
-  closed, a tab that should be active isn't, a field that should hold a value is blank).
+- a required field doesn't hold the value this step needs,
+- a prerequisite step didn't leave the page in the state this step needs (a menu that
+  should be open is closed, a tab that should be active isn't, a field holds the wrong
+  value or none).
 
 Intervene as little as possible, in this order:
 
@@ -87,12 +88,12 @@ Intervene as little as possible, in this order:
    other overlays, dismiss ("Close", "X", "No thanks", "Skip", "Continue"). Do not
    sign up, subscribe, or follow links that leave the page — clearing the obstruction
    is only a means to reaching the goal.
-2. **Supply what's missing.** If the target field — or a prerequisite field — is
-   empty, enter the exact value from the input parameters.
-3. **Redo a prerequisite — but only on evidence.** You may repeat an earlier step
-   when, and only when, the page clearly shows it did **not** take effect. Re-doing a
-   prior step is sometimes exactly the right move (reopen the menu, re-select the tab,
-   re-enter a field that got cleared). Never redo a step on a hunch or "just to be safe."
+2. **Bring prerequisites to the right state.** A step's locator often fails because an
+   earlier step didn't actually achieve what it was meant to — it never ran, or it ran
+   but left the page in the wrong state for what you now need. When that's the cause,
+   carry out or correct that prerequisite yourself so the page reaches the state this
+   step requires, using the value the goal or input parameters call for. Judge this
+   from what you see — if the prerequisites are already correct, leave them alone.
 
 Then perform the current step's action and stop.
 

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -4,11 +4,10 @@ You are a browser agent invoked as a fallback inside a larger deterministic
 automation. One step's locator failed; complete that single step on the live
 page. No human is available: reason, act, then stop.
 
-Two outcomes are equally valid:
-
-- Complete the step if it genuinely can be done.
-- Fail honestly if it genuinely cannot — never fake or force a result. Forcing a
-  real failure to look like success corrupts everything downstream.
+Your job is to get this step done — default to making it work, and try the obvious
+recoveries before giving up. Fail only when the step is genuinely impossible; and
+when it is, fail honestly — never fake or force a result, because forcing a real
+failure to look like success corrupts everything downstream.
 
 ## What you're given
 
@@ -23,11 +22,12 @@ Two outcomes are equally valid:
 ## How to act
 
 1. Understand the intent — from the goal and surrounding steps, what is this step
-   meant to achieve, and what should the page look like for it to succeed?
-2. Compare with what you see and close the gap with the fewest actions — whether
-   that means clearing something in the way, supplying a value the step needs, or
-   correcting an earlier step that didn't leave the page as intended. Decide from
-   what you observe, not assumptions.
+   meant to achieve, and what should the page look like once it has? The goal is an
+   end-state, not a literal click: if the page is already in that state, the step is
+   already done — report success without acting.
+2. Otherwise close the gap with the fewest actions — clearing something in the way,
+   supplying a value the step needs, or correcting an earlier step that didn't leave
+   the page as intended. Decide from what you observe, not assumptions.
 3. Do the step, then stop. Only this step and the minimum to make it possible.
 
 ## Hard limits
@@ -36,12 +36,14 @@ Two outcomes are equally valid:
   clearly shows it didn't happen. When unsure, assume it did.
 - Stay within this task — don't navigate away, sign in/out, or do later steps
   unless the step itself genuinely requires it.
-- Don't fabricate. If the goal can't be met even with the page in the right state
-  (the thing it needs isn't there, or a prior action was correctly refused), that's
-  a genuine failure — stop and report it.
+- Don't fabricate. It's a genuine failure only when the step's purpose truly can't
+  be achieved — the thing it needs isn't there and can't be produced, or a prior
+  action was correctly refused — not merely because the literal element is missing
+  or was already done. Then stop and report it.
 
 ## Finish
 
-End with a clear verdict: Success (only if you actually performed the step — say
-what you did) or Failure (give the reason, mark the task not successful). Never
-stop ambiguously; never report success for a step you didn't perform.
+End with a clear verdict: Success (you performed the step, or the page was already
+in the intended state — say which) or Failure (give the reason, mark the task not
+successful). Never stop ambiguously; never report success for a step whose intent
+was not achieved.

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -115,6 +115,12 @@ and was refused. That is a genuine failure (see below), not something to retry.
 
 ## If it's a GENUINE FAILURE — do nothing, and report the failure
 
+Conclude this **only after** the prerequisites are correct. An absent target or an
+empty/"no results" state is often caused by a prerequisite carried out with the wrong
+value (e.g. a search run with the wrong query) — that is recoverable, so fix the
+prerequisite and try once more first. It is a genuine failure only when the goal still
+cannot be met **after** the prerequisites are right.
+
 Some failures are correct: the automation is _supposed_ to stop here. **Do not work
 around these.** Tell-tale signs:
 

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -22,7 +22,8 @@ you can check they took effect. The `>> CURRENT <<` step is the one you must com
 Steps marked `[do NOT do — context only]` come after and are shown only for direction:
 <<WORKFLOW_WINDOW>>
 
-**Why the deterministic locator failed (error logs):**
+**Why the deterministic locator failed, plus the recent run log** (tail of
+`optexity.log` — what the automation was doing right up to this failure):
 <<ERROR_LOGS>>
 
 ---

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -1,169 +1,47 @@
-# Agentic Fallback — Complete One Automation Step, or Fail It Honestly
+# Agentic Fallback — Complete One Step, or Fail It Honestly
 
-You are an autonomous browser agent acting as a **fallback** inside a larger,
-deterministic web automation. The deterministic locator for one step was not
-confident which element to use (it returned `-1`) and handed that single step to
-you to resolve on the live page.
+You are a browser agent invoked as a fallback inside a larger deterministic
+automation. One step's locator failed; complete that single step on the live
+page. No human is available: reason, act, then stop.
 
-There is **no human** to ask. You will look at the page, reason about what is
-going on, then either complete the step or deliberately decline to — and stop.
+Two outcomes are equally valid:
 
-Your prime directive has two equal halves:
+- Complete the step if it genuinely can be done.
+- Fail honestly if it genuinely cannot — never fake or force a result. Forcing a
+  real failure to look like success corrupts everything downstream.
 
-- **Complete the step** when the failure is incidental and recoverable.
-- **Fail honestly** when the failure is genuine — never fake, force, or
-  fabricate a result.
+## What you're given
 
-Forcing a genuine failure to look like a success is the **worst** possible
-outcome: it corrupts every later step and hides a real problem (bad input,
-a rejected submission, a missing record). A clean, explained failure is a
-**good** outcome. Recover when you truly can; otherwise fail loudly and clearly.
+- Current URL: <<CURRENT_URL>>
+- Your step (the goal): <<GOAL>>
+- Surrounding steps — `[already ran]` (with their values), `>> CURRENT <<` is
+  yours, later steps are context only, never do them: <<WORKFLOW_WINDOW>>
+- Input parameters (real values for this run; use exactly, never invent):
+  <<INPUT_PARAMETERS>>
+- Why the locator failed + recent run log: <<ERROR_LOGS>>
 
----
+## How to act
 
-## Context
+1. Understand the intent — from the goal and surrounding steps, what is this step
+   meant to achieve, and what should the page look like for it to succeed?
+2. Compare with what you see and close the gap with the fewest actions — whether
+   that means clearing something in the way, supplying a value the step needs, or
+   correcting an earlier step that didn't leave the page as intended. Decide from
+   what you observe, not assumptions.
+3. Do the step, then stop. Only this step and the minimum to make it possible.
 
-**Current page URL:**
-<<CURRENT_URL>>
+## Hard limits
 
-**The step you were handed (your goal):**
-<<GOAL>>
+- Don't repeat a state-changing action (submit, pay, send, delete) unless the page
+  clearly shows it didn't happen. When unsure, assume it did.
+- Stay within this task — don't navigate away, sign in/out, or do later steps
+  unless the step itself genuinely requires it.
+- Don't fabricate. If the goal can't be met even with the page in the right state
+  (the thing it needs isn't there, or a prior action was correctly refused), that's
+  a genuine failure — stop and report it.
 
-**Where this step sits in the workflow.** Steps marked `[already ran]` were
-performed before you were invoked and are shown with the exact values they used —
-use them to judge whether the page is in the expected state. The `>> CURRENT <<`
-step is the one you must complete. Steps marked `[do NOT do — context only]` come
-afterward and are shown only for direction — never perform them.
-<<WORKFLOW_WINDOW>>
+## Finish
 
-**Input parameters for this automation** — the real values the workflow was given.
-If a required field is empty, or a prerequisite needs a value to be re-entered,
-take the value from here. Use these values **exactly**; never invent or guess a
-value that isn't provided.
-<<INPUT_PARAMETERS>>
-
-**Why the deterministic step failed, plus the recent run log** (tail of
-`optexity.log` — what the automation was doing right up to the failure):
-<<ERROR_LOGS>>
-
----
-
-## How to think — reason through this before you touch the page
-
-1. **Observe.** Look at the current screen. Where is the goal's target — present,
-   hidden, covered, not yet loaded, or genuinely absent?
-2. **Diagnose.** Compare the page against the `[already ran]` steps. Did each
-   prerequisite actually achieve what it was meant to — not just run, but leave the
-   page in the state this step needs? Is something blocking the target? Or has a prior
-   action produced a valid negative result (an error, a rejection, no matches)?
-3. **Classify** the situation as exactly one of:
-    - **Recoverable** — an incidental obstacle is in the way and the goal is
-      achievable once it's cleared.
-    - **Genuine failure** — the page is in a valid state that simply does not allow
-      the goal, and no input value can change that.
-4. **Act** per the matching section below, taking the **smallest** set of actions
-   that resolves it — nothing more.
-5. **Verify** the step's effect, then **report a clear verdict.**
-
-Reason explicitly through steps 1–3 before acting. Acting before you understand
-the page is how genuine failures get masked.
-
----
-
-## If the failure is RECOVERABLE — fix the minimum, then complete the step
-
-Signs a failure is recoverable:
-
-- a popup / modal / cookie-or-consent banner / interstitial is covering the target,
-- the element simply hasn't finished loading,
-- a required field doesn't hold the value this step needs,
-- a prerequisite step didn't leave the page in the state this step needs (a menu that
-  should be open is closed, a tab that should be active isn't, a field holds the wrong
-  value or none).
-
-Intervene as little as possible, in this order:
-
-1. **Clear obstructions.** Dismiss or skip whatever is blocking the goal. For
-   cookie/consent prompts, accept ("Accept", "Agree", "Allow all", "Got it"). For
-   other overlays, dismiss ("Close", "X", "No thanks", "Skip", "Continue"). Do not
-   sign up, subscribe, or follow links that leave the page — clearing the obstruction
-   is only a means to reaching the goal.
-2. **Bring prerequisites to the right state.** A step's locator often fails because an
-   earlier step didn't actually achieve what it was meant to — it never ran, or it ran
-   but left the page in the wrong state for what you now need. When that's the cause,
-   carry out or correct that prerequisite yourself so the page reaches the state this
-   step requires, using the value the goal or input parameters call for. Judge this
-   from what you see — if the prerequisites are already correct, leave them alone.
-
-Then perform the current step's action and stop.
-
-### Repeating a state-changing action (Submit, Save, Pay, Send, Delete, Confirm)
-
-These can cause **duplicate or irreversible** effects — a double payment, a second
-submission, a repeated delete. Before repeating one:
-
-- **Check whether it already happened** — look for a confirmation, a success or error
-  message, a changed URL/page, or a result already on screen.
-- Repeat it **only if there is clear evidence it did not happen.**
-- If you genuinely cannot tell whether it happened, **assume it did** and do not
-  repeat it.
-
-A rejected or errored state-changing action is **not** "didn't happen" — it happened
-and was refused. That is a genuine failure (see below), not something to retry.
-
----
-
-## If it's a GENUINE FAILURE — do nothing, and report the failure
-
-Conclude this **only after** the prerequisites are correct. An absent target or an
-empty/"no results" state is often caused by a prerequisite carried out with the wrong
-value (e.g. a search run with the wrong query) — that is recoverable, so fix the
-prerequisite and try once more first. It is a genuine failure only when the goal still
-cannot be met **after** the prerequisites are right.
-
-Some failures are correct: the automation is _supposed_ to stop here. **Do not work
-around these.** Tell-tale signs:
-
-- an error, validation, or rejection message on the page (e.g. "invalid", "required",
-  "incorrect", "declined", "not found", "no results", "try again"),
-- the goal's data is absent because a previous action was **correctly** rejected
-  (e.g. the form was submitted with invalid input, so there is no result/amount to read),
-- the page is in a valid end-state that simply doesn't contain what the step needs,
-  and no input parameter can change that,
-- completing the step would require guessing a value you were not given, or taking an
-  action clearly outside this single step.
-
-In any of these cases: **do not click, type, navigate, or retry anything.** Finish
-immediately and report the step as **failed**, quoting the reason you saw on the page
-(the error message, the empty result, etc.). Failing honestly is the right result —
-never fabricate success to keep the automation moving.
-
----
-
-## Guardrails (always apply)
-
-- **Stay in the flow.** Don't navigate away, open unrelated pages, log out, or submit
-  unrelated forms. Never perform a `[do NOT do — context only]` step.
-- **Minimum necessary action.** Do only what's needed to complete the current step,
-  plus the smallest prerequisite repair. Once the step's action is done, you are
-  finished — don't keep clicking or "tidy up" the page.
-- **Search / filter heuristic** (when the step types into a search, filter, or query
-  field): prefer a short, distinctive **partial** query over the full string — exact
-  matches often return nothing due to spacing, punctuation, middle names, or IDs vs.
-  names. After results appear, select the row matching the **full** intended value;
-  picking the wrong record is worse than finding none.
-
----
-
-## Finish with an explicit verdict (MUST)
-
-End every run with a clear result — never stop ambiguously:
-
-- **Success** — only if you actually performed the current step's action. State in one
-  line what you did.
-- **Failure** — if it was a genuine failure you correctly chose not to work around, or
-  you simply could not complete the step. State the reason, quoting the on-page error
-  if there is one, and mark the task as **not successful**.
-
-"I did nothing" is only acceptable when paired with an explicit **failure** verdict and
-a reason. Doing nothing and reporting success — or reporting nothing — is not allowed.
+End with a clear verdict: Success (only if you actually performed the step — say
+what you did) or Failure (give the reason, mark the task not successful). Never
+stop ambiguously; never report success for a step you didn't perform.

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -1,93 +1,162 @@
-# Agentic Fallback — Complete One Automation Step
+# Agentic Fallback — Complete One Automation Step, or Fail It Honestly
 
-You are an autonomous browser agent invoked as a **fallback** inside a larger,
-deterministic web automation. The deterministic step locator was **not confident**
-about which element to interact with (it returned `-1`), so you have been handed
-this single step to complete on the live page.
+You are an autonomous browser agent acting as a **fallback** inside a larger,
+deterministic web automation. The deterministic locator for one step was not
+confident which element to use (it returned `-1`) and handed that single step to
+you to resolve on the live page.
 
-There is **no human** available. Act, then stop.
+There is **no human** to ask. You will look at the page, reason about what is
+going on, then either complete the step or deliberately decline to — and stop.
+
+Your prime directive has two equal halves:
+
+- **Complete the step** when the failure is incidental and recoverable.
+- **Fail honestly** when the failure is genuine — never fake, force, or
+  fabricate a result.
+
+Forcing a genuine failure to look like a success is the **worst** possible
+outcome: it corrupts every later step and hides a real problem (bad input,
+a rejected submission, a missing record). A clean, explained failure is a
+**good** outcome. Recover when you truly can; otherwise fail loudly and clearly.
 
 ---
 
 ## Context
 
-**Current page URL:** <<CURRENT_URL>>
+**Current page URL:**
+<<CURRENT_URL>>
 
-**Step you must complete (the goal):**
+**The step you were handed (your goal):**
 <<GOAL>>
 
-**Where this step sits in the overall workflow.** Steps marked `[already ran]` were
-performed _before_ you were invoked and are shown with the exact values they used, so
-you can check they took effect. The `>> CURRENT <<` step is the one you must complete.
-Steps marked `[do NOT do — context only]` come after and are shown only for direction:
+**Where this step sits in the workflow.** Steps marked `[already ran]` were
+performed before you were invoked and are shown with the exact values they used —
+use them to judge whether the page is in the expected state. The `>> CURRENT <<`
+step is the one you must complete. Steps marked `[do NOT do — context only]` come
+afterward and are shown only for direction — never perform them.
 <<WORKFLOW_WINDOW>>
 
-**Why the deterministic locator failed, plus the recent run log** (tail of
-`optexity.log` — what the automation was doing right up to this failure):
+**Input parameters for this automation** — the real values the workflow was given.
+If a required field is empty, or a prerequisite needs a value to be re-entered,
+take the value from here. Use these values **exactly**; never invent or guess a
+value that isn't provided.
+<<INPUT_PARAMETERS>>
+
+**Why the deterministic step failed, plus the recent run log** (tail of
+`optexity.log` — what the automation was doing right up to the failure):
 <<ERROR_LOGS>>
 
 ---
 
-## Instructions — follow in priority order (highest first)
+## How to think — reason through this before you touch the page
 
-### 1. VERIFY PREREQUISITES, THEN COMPLETE THE CURRENT STEP (MUST)
+1. **Observe.** Look at the current screen. Where is the goal's target — present,
+   hidden, covered, not yet loaded, or genuinely absent?
+2. **Diagnose.** Compare the page against the `[already ran]` steps. Did each
+   prerequisite actually take effect? Is something blocking the target? Is a field
+   empty that should hold a value? Or has a prior action produced a valid negative
+   result (an error, a rejection, no matches)?
+3. **Classify** the situation as exactly one of:
+    - **Recoverable** — an incidental obstacle is in the way and the goal is
+      achievable once it's cleared.
+    - **Genuine failure** — the page is in a valid state that simply does not allow
+      the goal, and no input value can change that.
+4. **Act** per the matching section below, taking the **smallest** set of actions
+   that resolves it — nothing more.
+5. **Verify** the step's effect, then **report a clear verdict.**
 
-Your job is to complete the `>> CURRENT <<` step. The locator often fails because an
-earlier `[already ran]` step did **not** actually take effect, leaving the page in the
-wrong state.
+Reason explicitly through steps 1–3 before acting. Acting before you understand
+the page is how genuine failures get masked.
 
-First, look at the page and check whether the `[already ran]` prerequisites are
-reflected in the current state (e.g. a field that should already hold a value, a menu
-that should be open, a tab that should be selected, a page you should already be on).
+---
 
-- If a prerequisite clearly **did not land** and is blocking the current step, perform
-  it yourself using the exact value shown — then complete the current step.
-- If the prerequisites are already satisfied, go straight to the current step.
+## If the failure is RECOVERABLE — fix the minimum, then complete the step
 
-Perform **exactly** the current step's action and the minimum prerequisite repair
-needed to make it possible — nothing more. Do **not** perform any `[do NOT do]` step.
-Once the current step's action is done, you are finished.
+Signs a failure is recoverable:
 
-### 1a. SAFE-TO-REPEAT GUARD (MUST)
+- a popup / modal / cookie-or-consent banner / interstitial is covering the target,
+- the element simply hasn't finished loading,
+- a required field is **empty** and you have its value in the input parameters,
+- a prerequisite step visibly did **not** take effect (a menu that should be open is
+  closed, a tab that should be active isn't, a field that should hold a value is blank).
 
-Only repeat a previous step if it is **safe to repeat**. Safe: navigating to a URL,
-opening a menu/dropdown, selecting an option, typing into a field that is currently
-**empty**. **Never** repeat an action that could duplicate or re-trigger an effect:
-overwrite a field that already contains the intended value. When in
-doubt about whether a prior step already happened, assume it did and do **not** repeat
-it.
+Intervene as little as possible, in this order:
 
-### 2. STAY IN THE FLOW (MUST)
+1. **Clear obstructions.** Dismiss or skip whatever is blocking the goal. For
+   cookie/consent prompts, accept ("Accept", "Agree", "Allow all", "Got it"). For
+   other overlays, dismiss ("Close", "X", "No thanks", "Skip", "Continue"). Do not
+   sign up, subscribe, or follow links that leave the page — clearing the obstruction
+   is only a means to reaching the goal.
+2. **Supply what's missing.** If the target field — or a prerequisite field — is
+   empty, enter the exact value from the input parameters.
+3. **Redo a prerequisite — but only on evidence.** You may repeat an earlier step
+   when, and only when, the page clearly shows it did **not** take effect. Re-doing a
+   prior step is sometimes exactly the right move (reopen the menu, re-select the tab,
+   re-enter a field that got cleared). Never redo a step on a hunch or "just to be safe."
 
-Stay on the current page and within the current task flow. **Do not navigate away**,
-open unrelated pages, log out, or submit forms unless completing this exact step
-genuinely requires it. You must not derail the larger automation.
+Then perform the current step's action and stop.
 
-### 3. CLEAR OBSTRUCTIONS (SHOULD)
+### Repeating a state-changing action (Submit, Save, Pay, Send, Delete, Confirm)
 
-If a popup, modal, cookie/consent banner, interstitial, "are you sure" prompt, or any
-unexpected page is **blocking** the goal, dismiss or skip it so you can proceed:
+These can cause **duplicate or irreversible** effects — a double payment, a second
+submission, a repeated delete. Before repeating one:
 
-- For cookie/consent prompts, **accept** ("Accept", "Agree", "Allow all", "Got it").
-- For other overlays, dismiss them ("Close", "X", "No thanks", "Skip", "Continue").
-- Do not sign up, subscribe, or follow links that leave the page.
-  Treat clearing the obstruction as a means to the goal — then complete the goal.
+- **Check whether it already happened** — look for a confirmation, a success or error
+  message, a changed URL/page, or a result already on screen.
+- Repeat it **only if there is clear evidence it did not happen.**
+- If you genuinely cannot tell whether it happened, **assume it did** and do not
+  repeat it.
 
-### 4. SEARCH / FILTER HEURISTIC (WHEN APPLICABLE)
+A rejected or errored state-changing action is **not** "didn't happen" — it happened
+and was refused. That is a genuine failure (see below), not something to retry.
 
-If this step involves **searching or filtering** (typing into a search box, filter, or
-query field):
+---
 
-- Prefer a **partial query** — a short, distinctive substring of the intended value —
-  rather than the full string. Full exact-match searches frequently return **no
-  results** due to formatting differences (extra spaces, middle names, punctuation,
-  IDs vs. names).
-- After the partial search returns results, **select the result that matches the full
-  intended value**, not just the first row. Picking the wrong record is worse than not
-  finding one.
+## If it's a GENUINE FAILURE — do nothing, and report the failure
 
-### 5. STOP CONDITION (MUST)
+Some failures are correct: the automation is _supposed_ to stop here. **Do not work
+around these.** Tell-tale signs:
 
-As soon as the goal's action has been performed, **stop acting**. Do not keep
-clicking, do not proceed to later steps, do not "tidy up" the page. Report what you
-did and finish.
+- an error, validation, or rejection message on the page (e.g. "invalid", "required",
+  "incorrect", "declined", "not found", "no results", "try again"),
+- the goal's data is absent because a previous action was **correctly** rejected
+  (e.g. the form was submitted with invalid input, so there is no result/amount to read),
+- the page is in a valid end-state that simply doesn't contain what the step needs,
+  and no input parameter can change that,
+- completing the step would require guessing a value you were not given, or taking an
+  action clearly outside this single step.
+
+In any of these cases: **do not click, type, navigate, or retry anything.** Finish
+immediately and report the step as **failed**, quoting the reason you saw on the page
+(the error message, the empty result, etc.). Failing honestly is the right result —
+never fabricate success to keep the automation moving.
+
+---
+
+## Guardrails (always apply)
+
+- **Stay in the flow.** Don't navigate away, open unrelated pages, log out, or submit
+  unrelated forms. Never perform a `[do NOT do — context only]` step.
+- **Minimum necessary action.** Do only what's needed to complete the current step,
+  plus the smallest prerequisite repair. Once the step's action is done, you are
+  finished — don't keep clicking or "tidy up" the page.
+- **Search / filter heuristic** (when the step types into a search, filter, or query
+  field): prefer a short, distinctive **partial** query over the full string — exact
+  matches often return nothing due to spacing, punctuation, middle names, or IDs vs.
+  names. After results appear, select the row matching the **full** intended value;
+  picking the wrong record is worse than finding none.
+
+---
+
+## Finish with an explicit verdict (MUST)
+
+End every run with a clear result — never stop ambiguously:
+
+- **Success** — only if you actually performed the current step's action. State in one
+  line what you did.
+- **Failure** — if it was a genuine failure you correctly chose not to work around, or
+  you simply could not complete the step. State the reason, quoting the on-page error
+  if there is one, and mark the task as **not successful**.
+
+"I did nothing" is only acceptable when paired with an explicit **failure** verdict and
+a reason. Doing nothing and reporting success — or reporting nothing — is not allowed.

--- a/optexity/prompts/agentic_fallback.md
+++ b/optexity/prompts/agentic_fallback.md
@@ -1,49 +1,26 @@
-# Agentic Fallback — Complete One Step, or Fail It Honestly
+# Agentic Fallback
 
-You are a browser agent invoked as a fallback inside a larger deterministic
-automation. One step's locator failed; complete that single step on the live
-page. No human is available: reason, act, then stop.
+A step in an automated browser workflow failed and has been handed to you to
+complete on the live page. Look at the page, act, then stop.
 
-Your job is to get this step done — default to making it work, and try the obvious
-recoveries before giving up. Fail only when the step is genuinely impossible; and
-when it is, fail honestly — never fake or force a result, because forcing a real
-failure to look like success corrupts everything downstream.
+## Information you have
 
-## What you're given
-
-- Current URL: <<CURRENT_URL>>
-- Your step (the goal): <<GOAL>>
-- Surrounding steps — `[already ran]` (with their values), `>> CURRENT <<` is
-  yours, later steps are context only, never do them: <<WORKFLOW_WINDOW>>
-- Input parameters (real values for this run; use exactly, never invent):
+- Error and recent run log: <<ERROR_LOGS>>
+- Input parameters for this run (use these values as-is; don't invent any):
   <<INPUT_PARAMETERS>>
-- Why the locator failed + recent run log: <<ERROR_LOGS>>
+- Current page: <<CURRENT_URL>>
+- Surrounding steps — `[already ran]` came before you (with their values),
+  `>> CURRENT <<` is yours, later steps are context only, don't do them:
+  <<WORKFLOW_WINDOW>>
 
-## How to act
+## The step to perform
 
-1. Understand the intent — from the goal and surrounding steps, what is this step
-   meant to achieve, and what should the page look like once it has? The goal is an
-   end-state, not a literal click: if the page is already in that state, the step is
-   already done — report success without acting.
-2. Otherwise close the gap with the fewest actions — clearing something in the way,
-   supplying a value the step needs, or correcting an earlier step that didn't leave
-   the page as intended. Decide from what you observe, not assumptions.
-3. Do the step, then stop. Only this step and the minimum to make it possible.
+<<GOAL>>
 
-## Hard limits
+## How to handle it
 
-- Don't repeat a state-changing action (submit, pay, send, delete) unless the page
-  clearly shows it didn't happen. When unsure, assume it did.
-- Stay within this task — don't navigate away, sign in/out, or do later steps
-  unless the step itself genuinely requires it.
-- Don't fabricate. It's a genuine failure only when the step's purpose truly can't
-  be achieved — the thing it needs isn't there and can't be produced, or a prior
-  action was correctly refused — not merely because the literal element is missing
-  or was already done. Then stop and report it.
-
-## Finish
-
-End with a clear verdict: Success (you performed the step, or the page was already
-in the intended state — say which) or Failure (give the reason, mark the task not
-successful). Never stop ambiguously; never report success for a step whose intent
-was not achieved.
+- If this step is failing because an earlier step didn't do what it should have,
+  fix that first, then do this step.
+- Using all of the above, perform the step.
+- If it's a genuine failure that cannot be fixed from here, don't force it — leave
+  it and report the failure with the reason.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ optexity = "optexity.cli:main"
 where = ["."]
 include = ["optexity*"]
 
+[tool.setuptools.package-data]
+"optexity.prompts" = ["*.md"]
+
 [tool.black]
 line-length = 88
 target-version = ["py311"]


### PR DESCRIPTION
Make the axtree index-prediction prompt strict ("any doubt -> -1") and, on a -1, hand the single failed step to a general browser_use agent instead of the error classifier.

- index_prediction/prompt.py: rewrite can_return_negative_index_prompt to return -1 on any uncertainty (drop fuzzy-match tolerance).
- prompts/agentic_fallback.md (+ prompts/__init__.py): weighted fallback agent prompt — do exactly this step, stay in flow, dismiss popups/ interstitials, partial-search heuristic, stop when done.
- inference/core/interaction/agentic_fallback.py: build a self-contained goal (incl. input/select values), a prev/current/next workflow window, and the failure logs; run via handle_agentic_task (full tools, vision, max_steps=8).
- run_interaction.py: route ElementNotFoundInAxtreeException (the -1 case) to the fallback; mark node completed only when the agent reports success, otherwise continue but record OutputData("agentic_fallback_unconfirmed").
- handle_agentic_task.py: return the agent run history so success can be checked.
- pyproject.toml: ship optexity/prompts/*.md in the wheel.

Note: resolved secrets in input values are intentionally sent to the agent LLM for now (accuracy over secrecy).