### PR TITLE
fix(2fa): select most recent code when multiple are found

### DIFF
--- a/optexity/inference/agents/two_fa_extraction/prompt.py
+++ b/optexity/inference/agents/two_fa_extraction/prompt.py
@@ -6,18 +6,18 @@ Carefully follow these instructions:
 1. Read each message in the list, looking for explicit 2FA codes.
 2. Extract only the codes that are clearly intended for authentication—do not extract any other numbers, words, or irrelevant information.
 3. Exclude numbers or text from headers, footers, signatures, or unrelated content, even if they appear similar to codes.
-4. If there are multiple distinct 2FA codes across the messages, return all of them as a list.
+4. If there are multiple distinct 2FA codes across the messages, return ONLY the code from the message with the most recent `timestamp`. Older codes are stale (e.g. from a previous attempt) and must be ignored.
 5. If you find no valid 2FA code in any message, return None.
 
 Sometimes you may be given additional, specific extraction instructions—always follow those if present and give them highest priority.
 
-Context: Messages may come from various platforms (such as email, chat, or Slack).
+Context: Messages may come from various platforms (such as email, chat, or Slack). Each message includes a `timestamp` (ISO 8601, timezone-aware) you can use to determine which code is the most recent.
 
 **Input:**
-- A list of messages to analyze.
+- A list of messages to analyze. Each message has `message_text` and `timestamp`.
 
 **Output:**
-- The extracted 2FA code (as a string), a list of codes (if multiple are found), or None if no code exists.
+- The single most recent valid 2FA code (as a string), or None if no code exists.
 
-Carefully consider the content of each message and reason step-by-step before providing your answer. Return only the code(s), with no extra commentary or explanation.
+Carefully consider the content of each message and reason step-by-step before providing your answer. Return only the most recent code, with no extra commentary or explanation.
 """

--- a/optexity/inference/agents/two_fa_extraction/two_fa_extraction.py
+++ b/optexity/inference/agents/two_fa_extraction/two_fa_extraction.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 class TwoFAExtractionOutput(BaseModel):
     code: str | list[str] | None = Field(
-        description="The 2FA code extracted from the messages."
+        description=(
+            "The single most recent 2FA code extracted from the messages, "
+            "or None if no valid code is present."
+        )
     )
 
 
@@ -34,8 +37,8 @@ class TwoFAExtraction:
             [/EXTRACTION INSTRUCTIONS]
             """
         final_prompt += f"""
-        [MESSAGES] 
-        {json.dumps([message.model_dump(include={"message_text"}) for message in messages], indent=2)} 
+        [MESSAGES]
+        {json.dumps([message.model_dump(include={"message_text", "timestamp"}, mode="json") for message in messages], indent=2)}
         [/MESSAGES]
         """
 

--- a/optexity/inference/core/run_two_fa.py
+++ b/optexity/inference/core/run_two_fa.py
@@ -68,7 +68,7 @@ async def run_two_fa_action(two_fa_action: TwoFAAction, memory: Memory, task: Ta
                 if isinstance(response.code, str):
                     code = response.code
                 elif isinstance(response.code, list):
-                    if len(response.code) > 0:
+                    if len(response.code) > 1:
                         raise ValueError(f"Multiple 2FA codes found, {response.code}")
                     else:
                         code = response.code[0]


### PR DESCRIPTION
When several distinct 2FA codes appear in the fetch window (e.g. a stale code from a previous attempt alongside the fresh one), the extraction agent now returns only the code from the most recent message instead of the run failing with "Multiple 2FA codes found".

- Send message timestamps to the extraction LLM and instruct it to pick the newest code by timestamp.
- Update output schema description accordingly.
- Keep a defensive guard at the call site that still raises only when the LLM returns more than one code despite the prompt; a single-element list is now unwrapped instead of incorrectly raising.