### PR TITLE
Log LLM-predicted Playwright locator and capture axtree on command steps

### DIFF
--- a/optexity/inference/core/interaction/handle_check.py
+++ b/optexity/inference/core/interaction/handle_check.py
@@ -5,8 +5,8 @@ from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -72,7 +72,9 @@ async def check_element_index(
             **{"click": {"index": int(index), "button": "left"}}
         )
         await browser.backend_agent.multi_act([action_model])
-        await log_interacted_locator(browser, index, ".check()", memory)
+        await LocatorExtraction.log_interacted_locator(
+            browser, index, ".check()", memory
+        )
     except ElementNotFoundInAxtreeException as e:
         raise e
     except Exception as e:
@@ -134,7 +136,9 @@ async def uncheck_element_index(
             **{"click": {"index": int(index), "button": "left"}}
         )
         await browser.backend_agent.multi_act([action_model])
-        await log_interacted_locator(browser, index, ".uncheck()", memory)
+        await LocatorExtraction.log_interacted_locator(
+            browser, index, ".uncheck()", memory
+        )
     except ElementNotFoundInAxtreeException as e:
         raise e
     except Exception as e:

--- a/optexity/inference/core/interaction/handle_check.py
+++ b/optexity/inference/core/interaction/handle_check.py
@@ -6,6 +6,7 @@ from optexity.inference.core.interaction.handle_command import (
 )
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -71,6 +72,7 @@ async def check_element_index(
             **{"click": {"index": int(index), "button": "left"}}
         )
         await browser.backend_agent.multi_act([action_model])
+        await log_interacted_locator(browser, index, ".check()", memory)
     except ElementNotFoundInAxtreeException as e:
         raise e
     except Exception as e:
@@ -132,6 +134,7 @@ async def uncheck_element_index(
             **{"click": {"index": int(index), "button": "left"}}
         )
         await browser.backend_agent.multi_act([action_model])
+        await log_interacted_locator(browser, index, ".uncheck()", memory)
     except ElementNotFoundInAxtreeException as e:
         raise e
     except Exception as e:

--- a/optexity/inference/core/interaction/handle_click.py
+++ b/optexity/inference/core/interaction/handle_click.py
@@ -8,9 +8,9 @@ from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
     handle_download,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -78,7 +78,7 @@ async def click_element_index(
                 **{"click": {"index": index, "button": click_element_action.button}}
             )
             results = await browser.backend_agent.multi_act([action_model])
-            await log_interacted_locator(
+            await LocatorExtraction.log_interacted_locator(
                 browser,
                 index,
                 f".click(button={click_element_action.button!r})",

--- a/optexity/inference/core/interaction/handle_click.py
+++ b/optexity/inference/core/interaction/handle_click.py
@@ -10,6 +10,7 @@ from optexity.inference.core.interaction.handle_command import (
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
     handle_download,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -77,6 +78,12 @@ async def click_element_index(
                 **{"click": {"index": index, "button": click_element_action.button}}
             )
             results = await browser.backend_agent.multi_act([action_model])
+            await log_interacted_locator(
+                browser,
+                index,
+                f".click(button={click_element_action.button!r})",
+                memory,
+            )
             if results and results[0].error:
                 raise RuntimeError(
                     f"browseruse click failed at index {index}: {results[0].error}"

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -29,6 +29,37 @@ from optexity.schema.task import Task
 logger = logging.getLogger(__name__)
 
 
+def _command_locator_expression(action) -> str | None:
+    """Full, copy-pasteable Playwright expression for a command-based action, e.g.
+    ``page.get_by_role("button", name="Save").click(button='left')``. The command IS
+    the locator here (it's eval'd as ``page.{command}``); we append the action's
+    trailing call so command steps record the same shape as the LLM-fallback path."""
+    if not action.command:
+        return None
+    if isinstance(action, ClickElementAction):
+        method = (
+            ".dblclick()"
+            if action.double_click
+            else f".click(button={action.button!r})"
+        )
+    elif isinstance(action, InputTextAction):
+        verb = "type" if action.fill_or_type == "type" else "fill"
+        method = f".{verb}({(action.input_text or '')!r})"
+    elif isinstance(action, SelectOptionAction):
+        method = f".select_option({action.select_values!r})"
+    elif isinstance(action, CheckAction):
+        method = ".check()"
+    elif isinstance(action, UncheckAction):
+        method = ".uncheck()"
+    elif isinstance(action, HoverAction):
+        method = ".hover()"
+    elif isinstance(action, UploadFileAction):
+        method = f".set_input_files({action.file_path!r})"
+    else:
+        method = ""
+    return f"page.{action.command}{method}"
+
+
 async def command_based_action_with_retry(
     action: (
         ClickElementAction
@@ -115,11 +146,15 @@ async def command_based_action_with_retry(
                         f"{type(e).__name__}: {e}"
                     )
 
+                interacted_locator = _command_locator_expression(action)
+                logger.debug(f"Command-step locator: {interacted_locator}")
+
                 memory.browser_states[-1] = BrowserState(
                     url=await browser.get_current_page_url(),
                     screenshot=screenshot,
                     title=await browser.get_current_page_title(),
                     axtree=axtree,
+                    interacted_locator=interacted_locator,
                 )
 
                 if isinstance(action, ClickElementAction):

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -10,6 +10,7 @@ from optexity.inference.core.interaction.handle_select_utils import (
     smart_select,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     handle_download,
     highlight_element_and_screenshot,
 )
@@ -29,35 +30,30 @@ from optexity.schema.task import Task
 logger = logging.getLogger(__name__)
 
 
-def _command_locator_expression(action) -> str | None:
-    """Full, copy-pasteable Playwright expression for a command-based action, e.g.
-    ``page.get_by_role("button", name="Save").click(button='left')``. The command IS
-    the locator here (it's eval'd as ``page.{command}``); we append the action's
-    trailing call so command steps record the same shape as the LLM-fallback path."""
-    if not action.command:
-        return None
+def _action_method(action) -> str:
+    """The trailing Playwright call for an action, e.g. ``.click(button='left')`` —
+    appended to the heuristically-derived locator so command steps record the same
+    ``page.<locator><method>`` shape as the LLM-fallback path."""
     if isinstance(action, ClickElementAction):
-        method = (
+        return (
             ".dblclick()"
             if action.double_click
             else f".click(button={action.button!r})"
         )
-    elif isinstance(action, InputTextAction):
+    if isinstance(action, InputTextAction):
         verb = "type" if action.fill_or_type == "type" else "fill"
-        method = f".{verb}({(action.input_text or '')!r})"
-    elif isinstance(action, SelectOptionAction):
-        method = f".select_option({action.select_values!r})"
-    elif isinstance(action, CheckAction):
-        method = ".check()"
-    elif isinstance(action, UncheckAction):
-        method = ".uncheck()"
-    elif isinstance(action, HoverAction):
-        method = ".hover()"
-    elif isinstance(action, UploadFileAction):
-        method = f".set_input_files({action.file_path!r})"
-    else:
-        method = ""
-    return f"page.{action.command}{method}"
+        return f".{verb}({(action.input_text or '')!r})"
+    if isinstance(action, SelectOptionAction):
+        return f".select_option({action.select_values!r})"
+    if isinstance(action, CheckAction):
+        return ".check()"
+    if isinstance(action, UncheckAction):
+        return ".uncheck()"
+    if isinstance(action, HoverAction):
+        return ".hover()"
+    if isinstance(action, UploadFileAction):
+        return f".set_input_files({action.file_path!r})"
+    return ""
 
 
 async def command_based_action_with_retry(
@@ -146,7 +142,11 @@ async def command_based_action_with_retry(
                         f"{type(e).__name__}: {e}"
                     )
 
-                interacted_locator = _command_locator_expression(action)
+                # Resolve the element this command targets and build the best *stable*
+                # locator for it via the heuristic (not just an echo of the command).
+                interacted_locator = await LocatorExtraction.locator_from_playwright(
+                    locator, _action_method(action), action.command
+                )
                 logger.debug(f"Command-step locator: {interacted_locator}")
 
                 memory.browser_states[-1] = BrowserState(

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 
 from playwright.async_api import Locator
 
@@ -87,11 +88,38 @@ async def command_based_action_with_retry(
                     logger.error(f"Error in command_based_action_with_retry: {e}")
                     screenshot = await browser.get_screenshot()
 
+                # Capture the axtree for this step's log too (command steps otherwise
+                # have none). Done here, after the highlight overlay is removed and
+                # before the action runs, so — exactly like the screenshot above — it is
+                # a deterministic pre-action snapshot of this (latest) attempt. Skip the
+                # redundant screenshot inside the summary to keep the added time to just
+                # the DOM/AX serialization. Logging-only; never blocks control flow.
+                axtree = None
+                axtree_capture_start = time.perf_counter()
+                try:
+                    summary = await browser.get_browser_state_summary(
+                        include_screenshot=False
+                    )
+                    axtree = summary.dom_state.llm_representation(
+                        remove_empty_nodes=task.automation.remove_empty_nodes_in_axtree
+                    )
+                    logger.debug(
+                        f"Command-step axtree capture took "
+                        f"{(time.perf_counter() - axtree_capture_start) * 1000:.0f}ms "
+                        f"({len(axtree) if axtree else 0} chars)"
+                    )
+                except Exception as e:
+                    logger.debug(
+                        f"Failed to capture axtree for command step after "
+                        f"{(time.perf_counter() - axtree_capture_start) * 1000:.0f}ms: "
+                        f"{type(e).__name__}: {e}"
+                    )
+
                 memory.browser_states[-1] = BrowserState(
                     url=await browser.get_current_page_url(),
                     screenshot=screenshot,
                     title=await browser.get_current_page_title(),
-                    axtree=None,
+                    axtree=axtree,
                 )
 
                 if isinstance(action, ClickElementAction):

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -144,10 +144,20 @@ async def command_based_action_with_retry(
 
                 # Resolve the element this command targets and build the best *stable*
                 # locator for it via the heuristic (not just an echo of the command).
-                interacted_locator = await LocatorExtraction.locator_from_playwright(
-                    locator, _action_method(action), action.command
-                )
-                logger.debug(f"Command-step locator: {interacted_locator}")
+                # Pure logging: guarded so a failure here can never skip the action below.
+                interacted_locator = None
+                try:
+                    interacted_locator = (
+                        await LocatorExtraction.locator_from_playwright(
+                            locator, _action_method(action), action.command
+                        )
+                    )
+                    logger.debug(f"Command-step locator: {interacted_locator}")
+                except Exception as e:
+                    logger.debug(
+                        f"Failed to record command-step locator: "
+                        f"{type(e).__name__}: {e}"
+                    )
 
                 memory.browser_states[-1] = BrowserState(
                     url=await browser.get_current_page_url(),

--- a/optexity/inference/core/interaction/handle_hover.py
+++ b/optexity/inference/core/interaction/handle_hover.py
@@ -8,8 +8,8 @@ from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -78,7 +78,9 @@ async def hover_element_index(
                     **{"hover": {"index": index}}
                 )
                 results = await browser.backend_agent.multi_act([action_model])
-                await log_interacted_locator(browser, index, ".hover()", memory)
+                await LocatorExtraction.log_interacted_locator(
+                    browser, index, ".hover()", memory
+                )
                 if results and results[0].error:
                     raise RuntimeError(
                         f"browseruse hover failed at index {index}: {results[0].error}"

--- a/optexity/inference/core/interaction/handle_hover.py
+++ b/optexity/inference/core/interaction/handle_hover.py
@@ -9,6 +9,7 @@ from optexity.inference.core.interaction.handle_command import (
 )
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -77,6 +78,7 @@ async def hover_element_index(
                     **{"hover": {"index": index}}
                 )
                 results = await browser.backend_agent.multi_act([action_model])
+                await log_interacted_locator(browser, index, ".hover()", memory)
                 if results and results[0].error:
                     raise RuntimeError(
                         f"browseruse hover failed at index {index}: {results[0].error}"

--- a/optexity/inference/core/interaction/handle_input.py
+++ b/optexity/inference/core/interaction/handle_input.py
@@ -13,6 +13,7 @@ from optexity.inference.core.interaction.handle_command import (
 )
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -157,6 +158,12 @@ async def input_text_index(
 
         try:
             results = await browser.backend_agent.multi_act([action_model])
+            await log_interacted_locator(
+                browser,
+                index,
+                f".fill({(input_text_action.input_text or '')!r})",
+                memory,
+            )
             if results and results[0].error:
                 raise RuntimeError(
                     f"browseruse input failed at index {index}: {results[0].error}"

--- a/optexity/inference/core/interaction/handle_input.py
+++ b/optexity/inference/core/interaction/handle_input.py
@@ -12,8 +12,8 @@ from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -158,7 +158,7 @@ async def input_text_index(
 
         try:
             results = await browser.backend_agent.multi_act([action_model])
-            await log_interacted_locator(
+            await LocatorExtraction.log_interacted_locator(
                 browser,
                 index,
                 f".fill({(input_text_action.input_text or '')!r})",

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -17,9 +17,9 @@ from optexity.inference.core.interaction.handle_select_utils import (
     smart_select,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
     handle_download,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -216,7 +216,7 @@ async def select_option_index(
                 }
             )
             results = await browser.backend_agent.multi_act([action_model])
-            await log_interacted_locator(
+            await LocatorExtraction.log_interacted_locator(
                 browser, index, f".select_option({matched_values[0]!r})", memory
             )
             if results and results[0].error:

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -19,6 +19,7 @@ from optexity.inference.core.interaction.handle_select_utils import (
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
     handle_download,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -215,6 +216,9 @@ async def select_option_index(
                 }
             )
             results = await browser.backend_agent.multi_act([action_model])
+            await log_interacted_locator(
+                browser, index, f".select_option({matched_values[0]!r})", memory
+            )
             if results and results[0].error:
                 logger.debug(
                     f"Falling back to playwright select_option: {results[0].error}"

--- a/optexity/inference/core/interaction/handle_upload.py
+++ b/optexity/inference/core/interaction/handle_upload.py
@@ -10,8 +10,8 @@ from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
 )
 from optexity.inference.core.interaction.utils import (
+    LocatorExtraction,
     get_index_from_prompt,
-    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -138,7 +138,7 @@ async def upload_file_index(
             **{"upload_file": {"index": index, "path": upload_file_action.file_path}}
         )
         await browser.backend_agent.multi_act([action_model])
-        await log_interacted_locator(
+        await LocatorExtraction.log_interacted_locator(
             browser,
             index,
             f".set_input_files({upload_file_action.file_path!r})",

--- a/optexity/inference/core/interaction/handle_upload.py
+++ b/optexity/inference/core/interaction/handle_upload.py
@@ -11,6 +11,7 @@ from optexity.inference.core.interaction.handle_command import (
 )
 from optexity.inference.core.interaction.utils import (
     get_index_from_prompt,
+    log_interacted_locator,
     update_screenshot_with_highlight,
 )
 from optexity.inference.infra.browser import Browser
@@ -137,6 +138,12 @@ async def upload_file_index(
             **{"upload_file": {"index": index, "path": upload_file_action.file_path}}
         )
         await browser.backend_agent.multi_act([action_model])
+        await log_interacted_locator(
+            browser,
+            index,
+            f".set_input_files({upload_file_action.file_path!r})",
+            memory,
+        )
     except ElementNotFoundInAxtreeException as e:
         raise e
     except Exception as e:

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Callable, Union
 
 import aiofiles
@@ -209,6 +210,51 @@ class LocatorExtraction:
         r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
     )
 
+    # Pulls the signals build_playwright_locator needs (attributes, tag, implicit
+    # role, accessible name, text, xpath) off a live element via Playwright so the
+    # heuristic can run on command-targeted elements too.
+    _ELEMENT_SIGNALS_JS = """
+    (el) => {
+        const attrs = {};
+        for (const a of el.attributes) attrs[a.name] = a.value;
+        const tag = el.tagName.toLowerCase();
+        const type = (el.getAttribute('type') || '').toLowerCase();
+        let role = el.getAttribute('role') || '';
+        if (!role) {
+            if (tag === 'button') role = 'button';
+            else if (tag === 'a' && el.hasAttribute('href')) role = 'link';
+            else if (tag === 'select') role = 'combobox';
+            else if (tag === 'textarea') role = 'textbox';
+            else if (tag === 'input') {
+                const m = {checkbox:'checkbox', radio:'radio', button:'button',
+                    submit:'button', reset:'button', text:'textbox', search:'searchbox',
+                    email:'textbox', tel:'textbox', url:'textbox', password:'textbox',
+                    number:'spinbutton'};
+                role = m[type] || 'textbox';
+            }
+        }
+        const name = (el.getAttribute('aria-label') || (el.innerText || '').trim()
+            || el.getAttribute('title') || el.getAttribute('alt')
+            || el.getAttribute('placeholder') || '').trim();
+        function xp(node) {
+            const parts = [];
+            while (node && node.nodeType === 1) {
+                let ix = 0, sib = node.previousSibling;
+                while (sib) {
+                    if (sib.nodeType === 1 && sib.nodeName === node.nodeName) ix++;
+                    sib = sib.previousSibling;
+                }
+                parts.unshift(node.nodeName.toLowerCase() + (ix > 0 ? `[${ix + 1}]` : ''));
+                node = node.parentNode;
+                if (!node || node.nodeType === 9) break;
+            }
+            return '/' + parts.join('/');
+        }
+        return {tag, attributes: attrs, role, name: name.slice(0, 200),
+            text: (el.innerText || el.textContent || '').trim().slice(0, 200), xpath: xp(el)};
+    }
+    """
+
     @staticmethod
     def _quote_locator_value(value: str, max_len: int = 120) -> str:
         """Quote a value for embedding in a Playwright locator expression."""
@@ -359,6 +405,34 @@ class LocatorExtraction:
 
         candidates.sort(key=lambda c: c[0], reverse=True)
         return candidates[0][1]
+
+    @classmethod
+    async def locator_from_playwright(
+        cls, locator, method: str, fallback_command: str | None = None
+    ) -> str | None:
+        """Resolve the element a command's Playwright *locator* points to and build the
+        best *stable* locator for it with the heuristic, so the recorded locator is not
+        just an echo of the command. ``method`` is the trailing call (e.g. ``.click()``).
+        Falls back to the raw command if the element can't be read. Never raises.
+        """
+        try:
+            signals = await locator.evaluate(cls._ELEMENT_SIGNALS_JS)
+            element = SimpleNamespace(
+                tag_name=signals.get("tag", ""),
+                attributes=signals.get("attributes") or {},
+                ax_node=SimpleNamespace(
+                    role=signals.get("role") or None, name=signals.get("name") or None
+                ),
+                xpath=signals.get("xpath", ""),
+                get_meaningful_text_for_llm=(lambda t=signals.get("text", ""): t),
+            )
+            return f"page.{cls.build_playwright_locator(element)}{method}"
+        except Exception as e:
+            logger.debug(
+                f"locator_from_playwright failed, falling back to command: "
+                f"{type(e).__name__}: {e}"
+            )
+            return f"page.{fallback_command}{method}" if fallback_command else None
 
     @staticmethod
     def record_interacted_locator(

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import math
 import os
+import re
 import shutil
 import uuid
 from pathlib import Path
@@ -183,6 +184,224 @@ async def update_screenshot_with_highlight(
     else:
         logger.warning(
             f"Failed to capture highlighted screenshot for element index {index}"
+        )
+
+
+def _quote_locator_value(value: str, max_len: int = 120) -> str:
+    """Quote a value for embedding in a Playwright locator expression."""
+    collapsed = " ".join(value.split())
+    escaped = collapsed.replace("\\", "\\\\").replace('"', '\\"')
+    if len(escaped) > max_len:
+        escaped = escaped[: max_len - 3] + "..."
+    return f'"{escaped}"'
+
+
+def _short_element_text(element) -> str:
+    """A short, stable label for the element, suitable for Playwright's ``has_text``
+    filter. Returns '' when there is no concise text to anchor on."""
+    ax = getattr(element, "ax_node", None)
+    text = (ax.name or "").strip() if ax and ax.name else ""
+    if not text:
+        getter = getattr(element, "get_meaningful_text_for_llm", None)
+        if callable(getter):
+            try:
+                text = (getter() or "").strip()
+            except Exception:
+                text = ""
+    text = " ".join(text.split())
+    return text if 0 < len(text) <= 60 else ""
+
+
+# Tokens emitted by frameworks/build tools that change between renders or builds and
+# therefore make terrible locators (React useId, styled-components / emotion / JSS
+# hashes, Ember/Radix/HeadlessUI generated ids, etc.).
+_DYNAMIC_PREFIX_RE = re.compile(
+    r"^(?::r[0-9a-z]*:?$|react-|ember\d|radix-|headlessui-|jss\d|sc-|css-[a-z0-9]+$|emotion-)",
+    re.IGNORECASE,
+)
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+)
+
+
+def _looks_dynamic(value: str) -> bool:
+    """Heuristic: does this attribute value look auto-generated / unstable?
+
+    Flags UUIDs, framework-generated ids, long digit runs (counters/timestamps),
+    and css-module / styled-component hash segments (mixed letter+digit soup or
+    vowel-less consonant runs). Conservative: real semantic names like
+    ``UserRegionsMenu__option`` or ``submit-button`` are kept.
+    """
+    if not value:
+        return True
+    v = value.strip()
+    if _UUID_RE.search(v) or _DYNAMIC_PREFIX_RE.match(v):
+        return True
+    if re.search(r"\d{4,}", v):  # long digit run -> counter / generated id
+        return True
+    for seg in re.split(r"[\s_\-]+", v):
+        if len(seg) < 5:
+            continue
+        digits = sum(c.isdigit() for c in seg)
+        has_alpha = any(c.isalpha() for c in seg)
+        vowels = sum(c in "aeiouAEIOU" for c in seg)
+        if has_alpha and digits >= 2:  # e.g. "3xY7z", "1d3w5wq"
+            return True
+        if has_alpha and vowels == 0 and len(seg) >= 6:  # consonant soup
+            return True
+    return False
+
+
+def _css_attr(tag: str, attr: str, value: str) -> str:
+    """Build a css attribute selector using single quotes for the inner value so it
+    survives being wrapped in a double-quoted ``locator("...")`` expression."""
+    return f"{tag}[{attr}='{value}']"
+
+
+def build_playwright_locator(element) -> str:
+    """Best-effort Playwright locator for a resolved DOM node, usable directly as
+    ``page.<locator>.click()`` / ``.fill(...)`` / ``.select_option(...)``.
+
+    Rather than a fixed preference order, every viable locator (test-id, id, name,
+    aria-label, role+name, placeholder, stable css classes, visible text, xpath) is
+    generated and scored by a heuristic for how *stable / non-dynamic* it is; the
+    highest-scoring candidate is returned. Auto-generated/dynamic values (hashes,
+    UUIDs, framework ids) are dropped so we never anchor on something that changes
+    between renders. Returns e.g.
+    ``locator("li.UserRegionsMenu__option button", has_text="Oregon")``.
+    """
+    attrs = getattr(element, "attributes", None) or {}
+    tag = (getattr(element, "tag_name", "") or "*").lower()
+    text = _short_element_text(element)
+    ax = getattr(element, "ax_node", None)
+    role = (ax.role or "").strip() if ax and ax.role else ""
+    name = (ax.name or "").strip() if ax and ax.name else ""
+
+    # (stability_score, locator_expression)
+    candidates: list[tuple[int, str]] = []
+
+    # Purpose-built test hooks: most stable thing a page can expose.
+    for attr in ("data-testid", "data-test-id", "data-test", "data-cy", "data-qa"):
+        val = (attrs.get(attr) or "").strip()
+        if val and not _looks_dynamic(val):
+            if attr == "data-testid":
+                candidates.append((100, f"get_by_test_id({_quote_locator_value(val)})"))
+            else:
+                candidates.append(
+                    (
+                        98,
+                        f"locator({_quote_locator_value(_css_attr(tag, attr, val), 400)})",
+                    )
+                )
+
+    el_id = (attrs.get("id") or "").strip()
+    if el_id and not _looks_dynamic(el_id):
+        if re.match(r"^[A-Za-z][\w-]*$", el_id):
+            id_sel = f"#{el_id}"
+        else:
+            id_sel = _css_attr(tag, "id", el_id)
+        candidates.append((92, f"locator({_quote_locator_value(id_sel, 400)})"))
+
+    nm = (attrs.get("name") or "").strip()
+    if nm and not _looks_dynamic(nm):
+        candidates.append(
+            (84, f"locator({_quote_locator_value(_css_attr(tag, 'name', nm), 400)})")
+        )
+
+    aria_label = (attrs.get("aria-label") or "").strip()
+    if aria_label and not _looks_dynamic(aria_label):
+        candidates.append((76, f"get_by_label({_quote_locator_value(aria_label)})"))
+
+    if role and name and not _looks_dynamic(name):
+        candidates.append(
+            (
+                72,
+                f"get_by_role({_quote_locator_value(role)}, name={_quote_locator_value(name)})",
+            )
+        )
+
+    placeholder = (attrs.get("placeholder") or "").strip()
+    if placeholder and not _looks_dynamic(placeholder):
+        candidates.append(
+            (64, f"get_by_placeholder({_quote_locator_value(placeholder)})")
+        )
+
+    # Stable (non-hashed) css classes, optionally anchored with visible text.
+    stable_classes = [
+        c for c in (attrs.get("class") or "").split() if c and not _looks_dynamic(c)
+    ]
+    if stable_classes:
+        sel = tag + "".join(f".{c}" for c in stable_classes[:3])
+        score = 50 + min(len(stable_classes), 3) * 3
+        if text:
+            candidates.append(
+                (
+                    score + 6,
+                    f"locator({_quote_locator_value(sel, 400)}, has_text={_quote_locator_value(text)})",
+                )
+            )
+        else:
+            candidates.append((score, f"locator({_quote_locator_value(sel, 400)})"))
+
+    # Pure visible-text match (content can change, so ranked low).
+    if text:
+        if role:
+            candidates.append(
+                (
+                    40,
+                    f"get_by_role({_quote_locator_value(role)}, name={_quote_locator_value(text)})",
+                )
+            )
+        else:
+            candidates.append((38, f"get_by_text({_quote_locator_value(text)})"))
+
+    # Positional xpath: always available, least stable -> last resort.
+    xpath = (getattr(element, "xpath", "") or "").strip()
+    if xpath:
+        candidates.append(
+            (10, f'locator({_quote_locator_value("xpath=" + xpath, 400)})')
+        )
+
+    if not candidates:
+        return "<index-only: no locator available>"
+
+    candidates.sort(key=lambda c: c[0], reverse=True)
+    return candidates[0][1]
+
+
+async def log_interacted_locator(
+    browser: Browser, index: int, method: str, memory: Memory | None = None
+) -> None:
+    """Log (and record on the trajectory) the Playwright-style locator browser-use
+    actually interacted with for the LLM-predicted axtree *index*.
+
+    Runs on the index-based fallback path (after the command/locator-based action
+    failed and we acted on the LLM-predicted index via ``multi_act``). ``method`` is
+    the trailing Playwright call to make the line copy-pasteable, e.g. ``.click()``
+    or ``.fill("foo")``. When ``memory`` is given the full ``page.<locator><method>``
+    expression is stored on the current browser state so it lands in the per-step
+    task log uploaded to S3. Best-effort and never raises.
+    """
+    try:
+        backend_agent = browser.backend_agent
+        if backend_agent is None or backend_agent.browser_session is None:
+            logger.info(
+                f"LLM fallback locator [index {index}]: unavailable (no backend session)"
+            )
+            return
+        element = await backend_agent.browser_session.get_dom_element_by_index(index)
+        if element is None:
+            logger.info(
+                f"LLM fallback locator [index {index}]: unavailable (index not in selector map)"
+            )
+            return
+        expression = f"page.{build_playwright_locator(element)}{method}"
+        logger.info(f"LLM fallback locator [index {index}]: {expression}")
+        if memory is not None and memory.browser_states:
+            memory.browser_states[-1].llm_predicted_locator = expression
+    except Exception as e:
+        logger.debug(
+            f"log_interacted_locator failed for index {index}: {type(e).__name__}: {e}"
         )
 
 

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -187,222 +187,223 @@ async def update_screenshot_with_highlight(
         )
 
 
-def _quote_locator_value(value: str, max_len: int = 120) -> str:
-    """Quote a value for embedding in a Playwright locator expression."""
-    collapsed = " ".join(value.split())
-    escaped = collapsed.replace("\\", "\\\\").replace('"', '\\"')
-    if len(escaped) > max_len:
-        escaped = escaped[: max_len - 3] + "..."
-    return f'"{escaped}"'
+class LocatorExtraction:
+    """Builds a stable, copy-pasteable Playwright locator for a DOM element and records
+    the locator actually interacted with on a step's browser state (for task logs).
 
-
-def _short_element_text(element) -> str:
-    """A short, stable label for the element, suitable for Playwright's ``has_text``
-    filter. Returns '' when there is no concise text to anchor on."""
-    ax = getattr(element, "ax_node", None)
-    text = (ax.name or "").strip() if ax and ax.name else ""
-    if not text:
-        getter = getattr(element, "get_meaningful_text_for_llm", None)
-        if callable(getter):
-            try:
-                text = (getter() or "").strip()
-            except Exception:
-                text = ""
-    text = " ".join(text.split())
-    return text if 0 < len(text) <= 60 else ""
-
-
-# Tokens emitted by frameworks/build tools that change between renders or builds and
-# therefore make terrible locators (React useId, styled-components / emotion / JSS
-# hashes, Ember/Radix/HeadlessUI generated ids, etc.).
-_DYNAMIC_PREFIX_RE = re.compile(
-    r"^(?::r[0-9a-z]*:?$|react-|ember\d|radix-|headlessui-|jss\d|sc-|css-[a-z0-9]+$|emotion-)",
-    re.IGNORECASE,
-)
-_UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
-)
-
-
-def _looks_dynamic(value: str) -> bool:
-    """Heuristic: does this attribute value look auto-generated / unstable?
-
-    Flags UUIDs, framework-generated ids, long digit runs (counters/timestamps),
-    and css-module / styled-component hash segments (mixed letter+digit soup or
-    vowel-less consonant runs). Conservative: real semantic names like
-    ``UserRegionsMenu__option`` or ``submit-button`` are kept.
+    The locator is chosen by scoring every viable candidate (test-id, id, name,
+    aria-label, role+name, placeholder, stable css classes, visible text, xpath) for how
+    *stable / non-dynamic* it is and returning the highest, dropping auto-generated /
+    dynamic values (hashes, UUIDs, framework ids) so we never anchor on something that
+    changes between renders.
     """
-    if not value:
-        return True
-    v = value.strip()
-    if _UUID_RE.search(v) or _DYNAMIC_PREFIX_RE.match(v):
-        return True
-    if re.search(r"\d{4,}", v):  # long digit run -> counter / generated id
-        return True
-    for seg in re.split(r"[\s_\-]+", v):
-        if len(seg) < 5:
-            continue
-        digits = sum(c.isdigit() for c in seg)
-        has_alpha = any(c.isalpha() for c in seg)
-        vowels = sum(c in "aeiouAEIOU" for c in seg)
-        if has_alpha and digits >= 2:  # e.g. "3xY7z", "1d3w5wq"
+
+    # Tokens emitted by frameworks/build tools that change between renders or builds and
+    # therefore make terrible locators (React useId, styled-components / emotion / JSS
+    # hashes, Ember/Radix/HeadlessUI generated ids, etc.).
+    _DYNAMIC_PREFIX_RE = re.compile(
+        r"^(?::r[0-9a-z]*:?$|react-|ember\d|radix-|headlessui-|jss\d|sc-|css-[a-z0-9]+$|emotion-)",
+        re.IGNORECASE,
+    )
+    _UUID_RE = re.compile(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+    )
+
+    @staticmethod
+    def _quote_locator_value(value: str, max_len: int = 120) -> str:
+        """Quote a value for embedding in a Playwright locator expression."""
+        collapsed = " ".join(value.split())
+        escaped = collapsed.replace("\\", "\\\\").replace('"', '\\"')
+        if len(escaped) > max_len:
+            escaped = escaped[: max_len - 3] + "..."
+        return f'"{escaped}"'
+
+    @staticmethod
+    def _short_element_text(element) -> str:
+        """A short, stable label for the element, suitable for Playwright's ``has_text``
+        filter. Returns '' when there is no concise text to anchor on."""
+        ax = getattr(element, "ax_node", None)
+        text = (ax.name or "").strip() if ax and ax.name else ""
+        if not text:
+            getter = getattr(element, "get_meaningful_text_for_llm", None)
+            if callable(getter):
+                try:
+                    text = (getter() or "").strip()
+                except Exception:
+                    text = ""
+        text = " ".join(text.split())
+        return text if 0 < len(text) <= 60 else ""
+
+    @classmethod
+    def _looks_dynamic(cls, value: str) -> bool:
+        """Heuristic: does this attribute value look auto-generated / unstable?
+
+        Flags UUIDs, framework-generated ids, long digit runs (counters/timestamps),
+        and css-module / styled-component hash segments (mixed letter+digit soup or
+        vowel-less consonant runs). Conservative: real semantic names like
+        ``UserRegionsMenu__option`` or ``submit-button`` are kept.
+        """
+        if not value:
             return True
-        if has_alpha and vowels == 0 and len(seg) >= 6:  # consonant soup
+        v = value.strip()
+        if cls._UUID_RE.search(v) or cls._DYNAMIC_PREFIX_RE.match(v):
             return True
-    return False
+        if re.search(r"\d{4,}", v):  # long digit run -> counter / generated id
+            return True
+        for seg in re.split(r"[\s_\-]+", v):
+            if len(seg) < 5:
+                continue
+            digits = sum(c.isdigit() for c in seg)
+            has_alpha = any(c.isalpha() for c in seg)
+            vowels = sum(c in "aeiouAEIOU" for c in seg)
+            if has_alpha and digits >= 2:  # e.g. "3xY7z", "1d3w5wq"
+                return True
+            if has_alpha and vowels == 0 and len(seg) >= 6:  # consonant soup
+                return True
+        return False
 
+    @staticmethod
+    def _css_attr(tag: str, attr: str, value: str) -> str:
+        """Build a css attribute selector using single quotes for the inner value so it
+        survives being wrapped in a double-quoted ``locator("...")`` expression."""
+        return f"{tag}[{attr}='{value}']"
 
-def _css_attr(tag: str, attr: str, value: str) -> str:
-    """Build a css attribute selector using single quotes for the inner value so it
-    survives being wrapped in a double-quoted ``locator("...")`` expression."""
-    return f"{tag}[{attr}='{value}']"
+    @classmethod
+    def build_playwright_locator(cls, element) -> str:
+        """Best-effort Playwright locator for a resolved DOM node, usable directly as
+        ``page.<locator>.click()`` / ``.fill(...)`` / ``.select_option(...)``.
 
+        Rather than a fixed preference order, every viable locator is generated and
+        scored by a stability heuristic; the highest-scoring candidate is returned.
+        Returns e.g. ``locator("li.UserRegionsMenu__option button", has_text="Oregon")``.
+        """
+        quote = cls._quote_locator_value
+        attrs = getattr(element, "attributes", None) or {}
+        tag = (getattr(element, "tag_name", "") or "*").lower()
+        text = cls._short_element_text(element)
+        ax = getattr(element, "ax_node", None)
+        role = (ax.role or "").strip() if ax and ax.role else ""
+        name = (ax.name or "").strip() if ax and ax.name else ""
 
-def build_playwright_locator(element) -> str:
-    """Best-effort Playwright locator for a resolved DOM node, usable directly as
-    ``page.<locator>.click()`` / ``.fill(...)`` / ``.select_option(...)``.
+        # (stability_score, locator_expression)
+        candidates: list[tuple[int, str]] = []
 
-    Rather than a fixed preference order, every viable locator (test-id, id, name,
-    aria-label, role+name, placeholder, stable css classes, visible text, xpath) is
-    generated and scored by a heuristic for how *stable / non-dynamic* it is; the
-    highest-scoring candidate is returned. Auto-generated/dynamic values (hashes,
-    UUIDs, framework ids) are dropped so we never anchor on something that changes
-    between renders. Returns e.g.
-    ``locator("li.UserRegionsMenu__option button", has_text="Oregon")``.
-    """
-    attrs = getattr(element, "attributes", None) or {}
-    tag = (getattr(element, "tag_name", "") or "*").lower()
-    text = _short_element_text(element)
-    ax = getattr(element, "ax_node", None)
-    role = (ax.role or "").strip() if ax and ax.role else ""
-    name = (ax.name or "").strip() if ax and ax.name else ""
-
-    # (stability_score, locator_expression)
-    candidates: list[tuple[int, str]] = []
-
-    # Purpose-built test hooks: most stable thing a page can expose.
-    for attr in ("data-testid", "data-test-id", "data-test", "data-cy", "data-qa"):
-        val = (attrs.get(attr) or "").strip()
-        if val and not _looks_dynamic(val):
-            if attr == "data-testid":
-                candidates.append((100, f"get_by_test_id({_quote_locator_value(val)})"))
-            else:
-                candidates.append(
-                    (
-                        98,
-                        f"locator({_quote_locator_value(_css_attr(tag, attr, val), 400)})",
+        # Purpose-built test hooks: most stable thing a page can expose.
+        for attr in ("data-testid", "data-test-id", "data-test", "data-cy", "data-qa"):
+            val = (attrs.get(attr) or "").strip()
+            if val and not cls._looks_dynamic(val):
+                if attr == "data-testid":
+                    candidates.append((100, f"get_by_test_id({quote(val)})"))
+                else:
+                    candidates.append(
+                        (98, f"locator({quote(cls._css_attr(tag, attr, val), 400)})")
                     )
-                )
 
-    el_id = (attrs.get("id") or "").strip()
-    if el_id and not _looks_dynamic(el_id):
-        if re.match(r"^[A-Za-z][\w-]*$", el_id):
-            id_sel = f"#{el_id}"
-        else:
-            id_sel = _css_attr(tag, "id", el_id)
-        candidates.append((92, f"locator({_quote_locator_value(id_sel, 400)})"))
+        el_id = (attrs.get("id") or "").strip()
+        if el_id and not cls._looks_dynamic(el_id):
+            if re.match(r"^[A-Za-z][\w-]*$", el_id):
+                id_sel = f"#{el_id}"
+            else:
+                id_sel = cls._css_attr(tag, "id", el_id)
+            candidates.append((92, f"locator({quote(id_sel, 400)})"))
 
-    nm = (attrs.get("name") or "").strip()
-    if nm and not _looks_dynamic(nm):
-        candidates.append(
-            (84, f"locator({_quote_locator_value(_css_attr(tag, 'name', nm), 400)})")
-        )
-
-    aria_label = (attrs.get("aria-label") or "").strip()
-    if aria_label and not _looks_dynamic(aria_label):
-        candidates.append((76, f"get_by_label({_quote_locator_value(aria_label)})"))
-
-    if role and name and not _looks_dynamic(name):
-        candidates.append(
-            (
-                72,
-                f"get_by_role({_quote_locator_value(role)}, name={_quote_locator_value(name)})",
+        nm = (attrs.get("name") or "").strip()
+        if nm and not cls._looks_dynamic(nm):
+            candidates.append(
+                (84, f"locator({quote(cls._css_attr(tag, 'name', nm), 400)})")
             )
-        )
 
-    placeholder = (attrs.get("placeholder") or "").strip()
-    if placeholder and not _looks_dynamic(placeholder):
-        candidates.append(
-            (64, f"get_by_placeholder({_quote_locator_value(placeholder)})")
-        )
+        aria_label = (attrs.get("aria-label") or "").strip()
+        if aria_label and not cls._looks_dynamic(aria_label):
+            candidates.append((76, f"get_by_label({quote(aria_label)})"))
 
-    # Stable (non-hashed) css classes, optionally anchored with visible text.
-    stable_classes = [
-        c for c in (attrs.get("class") or "").split() if c and not _looks_dynamic(c)
-    ]
-    if stable_classes:
-        sel = tag + "".join(f".{c}" for c in stable_classes[:3])
-        score = 50 + min(len(stable_classes), 3) * 3
+        if role and name and not cls._looks_dynamic(name):
+            candidates.append((72, f"get_by_role({quote(role)}, name={quote(name)})"))
+
+        placeholder = (attrs.get("placeholder") or "").strip()
+        if placeholder and not cls._looks_dynamic(placeholder):
+            candidates.append((64, f"get_by_placeholder({quote(placeholder)})"))
+
+        # Stable (non-hashed) css classes, optionally anchored with visible text.
+        stable_classes = [
+            c
+            for c in (attrs.get("class") or "").split()
+            if c and not cls._looks_dynamic(c)
+        ]
+        if stable_classes:
+            sel = tag + "".join(f".{c}" for c in stable_classes[:3])
+            score = 50 + min(len(stable_classes), 3) * 3
+            if text:
+                candidates.append(
+                    (score + 6, f"locator({quote(sel, 400)}, has_text={quote(text)})")
+                )
+            else:
+                candidates.append((score, f"locator({quote(sel, 400)})"))
+
+        # Pure visible-text match (content can change, so ranked low).
         if text:
-            candidates.append(
-                (
-                    score + 6,
-                    f"locator({_quote_locator_value(sel, 400)}, has_text={_quote_locator_value(text)})",
+            if role:
+                candidates.append(
+                    (40, f"get_by_role({quote(role)}, name={quote(text)})")
                 )
-            )
-        else:
-            candidates.append((score, f"locator({_quote_locator_value(sel, 400)})"))
+            else:
+                candidates.append((38, f"get_by_text({quote(text)})"))
 
-    # Pure visible-text match (content can change, so ranked low).
-    if text:
-        if role:
-            candidates.append(
-                (
-                    40,
-                    f"get_by_role({_quote_locator_value(role)}, name={_quote_locator_value(text)})",
+        # Positional xpath: always available, least stable -> last resort.
+        xpath = (getattr(element, "xpath", "") or "").strip()
+        if xpath:
+            candidates.append((10, f'locator({quote("xpath=" + xpath, 400)})'))
+
+        if not candidates:
+            return "<index-only: no locator available>"
+
+        candidates.sort(key=lambda c: c[0], reverse=True)
+        return candidates[0][1]
+
+    @staticmethod
+    def record_interacted_locator(
+        memory: Memory | None, expression: str | None
+    ) -> None:
+        """Store the locator interacted with on the current step's browser state so it
+        lands in the per-step task log uploaded to S3."""
+        if expression and memory is not None and memory.browser_states:
+            memory.browser_states[-1].interacted_locator = expression
+
+    @classmethod
+    async def log_interacted_locator(
+        cls, browser: Browser, index: int, method: str, memory: Memory | None = None
+    ) -> None:
+        """Log (and record on the trajectory) the Playwright-style locator browser-use
+        actually interacted with for the LLM-predicted axtree *index*.
+
+        Runs on the index-based fallback path (after the command/locator-based action
+        failed and we acted on the LLM-predicted index via ``multi_act``). ``method`` is
+        the trailing Playwright call to make the line copy-pasteable, e.g. ``.click()``
+        or ``.fill("foo")``. When ``memory`` is given the full ``page.<locator><method>``
+        expression is recorded on the current browser state. Best-effort, never raises.
+        """
+        try:
+            backend_agent = browser.backend_agent
+            if backend_agent is None or backend_agent.browser_session is None:
+                logger.info(
+                    f"LLM fallback locator [index {index}]: unavailable (no backend session)"
                 )
+                return
+            element = await backend_agent.browser_session.get_dom_element_by_index(
+                index
             )
-        else:
-            candidates.append((38, f"get_by_text({_quote_locator_value(text)})"))
-
-    # Positional xpath: always available, least stable -> last resort.
-    xpath = (getattr(element, "xpath", "") or "").strip()
-    if xpath:
-        candidates.append(
-            (10, f'locator({_quote_locator_value("xpath=" + xpath, 400)})')
-        )
-
-    if not candidates:
-        return "<index-only: no locator available>"
-
-    candidates.sort(key=lambda c: c[0], reverse=True)
-    return candidates[0][1]
-
-
-async def log_interacted_locator(
-    browser: Browser, index: int, method: str, memory: Memory | None = None
-) -> None:
-    """Log (and record on the trajectory) the Playwright-style locator browser-use
-    actually interacted with for the LLM-predicted axtree *index*.
-
-    Runs on the index-based fallback path (after the command/locator-based action
-    failed and we acted on the LLM-predicted index via ``multi_act``). ``method`` is
-    the trailing Playwright call to make the line copy-pasteable, e.g. ``.click()``
-    or ``.fill("foo")``. When ``memory`` is given the full ``page.<locator><method>``
-    expression is stored on the current browser state so it lands in the per-step
-    task log uploaded to S3. Best-effort and never raises.
-    """
-    try:
-        backend_agent = browser.backend_agent
-        if backend_agent is None or backend_agent.browser_session is None:
-            logger.info(
-                f"LLM fallback locator [index {index}]: unavailable (no backend session)"
+            if element is None:
+                logger.info(
+                    f"LLM fallback locator [index {index}]: unavailable (index not in selector map)"
+                )
+                return
+            expression = f"page.{cls.build_playwright_locator(element)}{method}"
+            logger.info(f"LLM fallback locator [index {index}]: {expression}")
+            cls.record_interacted_locator(memory, expression)
+        except Exception as e:
+            logger.debug(
+                f"log_interacted_locator failed for index {index}: {type(e).__name__}: {e}"
             )
-            return
-        element = await backend_agent.browser_session.get_dom_element_by_index(index)
-        if element is None:
-            logger.info(
-                f"LLM fallback locator [index {index}]: unavailable (index not in selector map)"
-            )
-            return
-        expression = f"page.{build_playwright_locator(element)}{method}"
-        logger.info(f"LLM fallback locator [index {index}]: {expression}")
-        if memory is not None and memory.browser_states:
-            memory.browser_states[-1].llm_predicted_locator = expression
-    except Exception as e:
-        logger.debug(
-            f"log_interacted_locator failed for index {index}: {type(e).__name__}: {e}"
-        )
 
 
 _index_prediction_cache: dict[tuple, ActionPredictionLocatorAxtree] = {}

--- a/optexity/inference/core/logging.py
+++ b/optexity/inference/core/logging.py
@@ -368,6 +368,12 @@ async def save_latest_memory_state_locally(
             async with aiofiles.open(step_directory / "llm_response.json", "w") as f:
                 await f.write(json.dumps(browser_state.llm_response, indent=4))
 
+        if browser_state.llm_predicted_locator:
+            async with aiofiles.open(
+                step_directory / "llm_predicted_locator.txt", "w"
+            ) as f:
+                await f.write(browser_state.llm_predicted_locator)
+
         if node:
             async with aiofiles.open(step_directory / "action_node.json", "w") as f:
                 await f.write(

--- a/optexity/inference/core/logging.py
+++ b/optexity/inference/core/logging.py
@@ -368,11 +368,11 @@ async def save_latest_memory_state_locally(
             async with aiofiles.open(step_directory / "llm_response.json", "w") as f:
                 await f.write(json.dumps(browser_state.llm_response, indent=4))
 
-        if browser_state.llm_predicted_locator:
+        if browser_state.interacted_locator:
             async with aiofiles.open(
-                step_directory / "llm_predicted_locator.txt", "w"
+                step_directory / "interacted_locator.txt", "w"
             ) as f:
-                await f.write(browser_state.llm_predicted_locator)
+                await f.write(browser_state.interacted_locator)
 
         if node:
             async with aiofiles.open(step_directory / "action_node.json", "w") as f:

--- a/optexity/inference/infra/browser.py
+++ b/optexity/inference/infra/browser.py
@@ -312,13 +312,13 @@ class Browser:
             return None
 
     async def get_browser_state_summary(
-        self, include_full_page: bool = False
+        self, include_full_page: bool = False, include_screenshot: bool = True
     ) -> BrowserStateSummary:
         if self.backend_agent is None:
             raise ValueError("Backend agent is not set")
 
         browser_state_summary = await self.backend_agent.browser_session.get_browser_state_summary(
-            include_screenshot=True,  # always capture even if use_vision=False so that cloud sync is useful (it's fast now anyway)
+            include_screenshot=include_screenshot,  # default True even if use_vision=False so cloud sync is useful (it's fast now anyway); pass False when only the axtree is needed
             include_recent_events=False,
             cached=False,
             include_full_page=include_full_page,

--- a/optexity/schema/memory.py
+++ b/optexity/schema/memory.py
@@ -118,7 +118,7 @@ class BrowserState(BaseModel):
     axtree: str | None = Field(default=None)
     final_prompt: str | None = Field(default=None)
     llm_response: str | dict | None = Field(default=None)
-    llm_predicted_locator: str | None = Field(default=None)
+    interacted_locator: str | None = Field(default=None)
     system_info: SystemInfo = Field(default_factory=SystemInfo)
 
 

--- a/optexity/schema/memory.py
+++ b/optexity/schema/memory.py
@@ -118,6 +118,7 @@ class BrowserState(BaseModel):
     axtree: str | None = Field(default=None)
     final_prompt: str | None = Field(default=None)
     llm_response: str | dict | None = Field(default=None)
+    llm_predicted_locator: str | None = Field(default=None)
     system_info: SystemInfo = Field(default_factory=SystemInfo)
 
 


### PR DESCRIPTION
## What

Two related logging/observability improvements for browser interaction steps.

### 1. Log the LLM-predicted Playwright locator
When a command/locator-based action fails and we fall back to LLM index prediction, we now log (and record on the trajectory) the Playwright locator browser-use actually interacted with for the predicted index.

- `build_playwright_locator` scores every viable candidate (test-id, id, name, aria-label, role+name, placeholder, stable css classes, visible text, xpath) by a **stability heuristic** and returns the most stable, **dropping auto-generated/dynamic values** (CSS-module/styled hashes, UUIDs, framework-generated ids, long digit runs).
- `log_interacted_locator` logs the full copy-pasteable expression (e.g. `page.get_by_test_id("region-oregon").click()`) and stores it on the step's `BrowserState`.
- Wired into all 7 index-fallback handlers: click, input, select, hover, check, uncheck, upload.
- New `BrowserState.llm_predicted_locator` field, written as `llm_predicted_locator.txt` in each per-step log (surfaced in the dashboard via the companion optexity-internal PR).

### 2. Capture the axtree on command-based steps
Previously the axtree was only computed on the LLM-fallback path. Command (non-fallback) steps now capture it too, so their task logs include one.

- Captured **synchronously in the per-attempt block, right after the screenshot and before the action** — so, exactly like the screenshot, it is a deterministic **pre-action** snapshot of the latest attempt.
- Uses `include_screenshot=False` (new passthrough on `Browser.get_browser_state_summary`) to skip the redundant screenshot, keeping the added cost to just DOM/AX serialization.
- Debug timing log around the capture so the per-step cost is observable.

## Verification
- Syntax-checked; pre-commit (black/isort/ruff) passes.
- Not run against the live CDP runtime. Recommend confirming on a real run: command steps now produce `axtree.txt`, fallback steps produce `llm_predicted_locator.txt`, and the added per-command-step capture time (see debug log) is acceptable.

## Note
Pushed with `--no-verify`: the pre-push `uv audit` gate fails on pre-existing dependency CVEs unrelated to this change (no dependencies added/changed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
