### PR TITLE
Record per-step action completion time in task logs

### DIFF
--- a/optexity/inference/core/logging.py
+++ b/optexity/inference/core/logging.py
@@ -324,6 +324,9 @@ async def save_latest_memory_state_locally(
 ):
 
     try:
+        # Captured here because this runs in run_node's `finally`, i.e. right after the
+        # step's action has completed (or failed) — so it is the action-completion time.
+        completed_at = datetime.now(timezone.utc).isoformat()
         browser_state = memory.browser_states[-1]
         automation_state = memory.automation_state
         step_directory = (
@@ -345,6 +348,8 @@ async def save_latest_memory_state_locally(
             "url": browser_state.url,
             "step_index": automation_state.step_index,
             "try_index": automation_state.try_index,
+            "completed_at": completed_at,
+            "started_at": (task.started_at.isoformat() if task.started_at else None),
             "downloaded_files": [
                 downloaded_file.name for downloaded_file in memory.downloads
             ],


### PR DESCRIPTION
## What
Record when each step's action completed in the per-step task log, so the dashboard can show timing.

- `save_latest_memory_state_locally` runs in `run_node`'s `finally` (right after the step's action completes/fails), so it captures `completed_at` there and writes it to `state.json`, along with the task's `started_at`.
- Both are ISO-8601 UTC; `started_at` is nullable (guarded).

Companion optexity-internal PR renders this: elapsed-from-start per step in the sidebar, and an absolute local completion time in the content header.

## Note
For a step whose action *failed*, `completed_at` is the `finally`-time (i.e. "step ended"), not a successful completion. Older trajectories without these fields degrade gracefully (UI anchors elapsed to the first step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
