### PR TITLE
refactor(models): remove unused structured output flag and simplify LLM interface

### DIFF
--- a/optexity/inference/core/interaction/handle_captcha.py
+++ b/optexity/inference/core/interaction/handle_captcha.py
@@ -162,7 +162,7 @@ async def _solve_and_click(
 
     max_retries = int(config.get("max_captcha_retries", 3))
     model_enum = GeminiModels(llm_model_name)
-    llm_model = get_llm_model(model_enum, True)
+    llm_model = get_llm_model(model_enum)
 
     refresh_count = 0
     while refresh_count <= max_retries:

--- a/optexity/inference/core/interaction/handle_input.py
+++ b/optexity/inference/core/interaction/handle_input.py
@@ -30,9 +30,7 @@ _input_text_prediction_cache: dict[tuple, InputTextPredictionAgent] = {}
 def _get_input_text_prediction_agent(task: Task) -> InputTextPredictionAgent:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _input_text_prediction_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _input_text_prediction_cache[cache_key] = InputTextPredictionAgent(model)
     return _input_text_prediction_cache[cache_key]
 

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -36,9 +36,7 @@ _select_option_prediction_cache: dict[tuple, SelectOptionPredictionAgent] = {}
 def _get_select_option_prediction_agent(task: Task) -> SelectOptionPredictionAgent:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _select_option_prediction_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _select_option_prediction_cache[cache_key] = SelectOptionPredictionAgent(model)
     return _select_option_prediction_cache[cache_key]
 

--- a/optexity/inference/core/interaction/handle_select_utils.py
+++ b/optexity/inference/core/interaction/handle_select_utils.py
@@ -19,9 +19,7 @@ _select_prediction_cache: dict[tuple, SelectValuePredictionAgent] = {}
 def _get_select_prediction_agent(task: Task) -> SelectValuePredictionAgent:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _select_prediction_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _select_prediction_cache[cache_key] = SelectValuePredictionAgent(model)
     return _select_prediction_cache[cache_key]
 

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -530,9 +530,7 @@ _index_prediction_cache: dict[tuple, ActionPredictionLocatorAxtree] = {}
 def _get_index_prediction_agent(task: "Task") -> ActionPredictionLocatorAxtree:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _index_prediction_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _index_prediction_cache[cache_key] = ActionPredictionLocatorAxtree(model)
     return _index_prediction_cache[cache_key]
 

--- a/optexity/inference/core/run_extraction.py
+++ b/optexity/inference/core/run_extraction.py
@@ -197,7 +197,7 @@ async def handle_llm_extraction(
 
     provider = llm_extraction.llm_provider or task.llm_provider
     model_name_str = llm_extraction.llm_model_name or task.llm_model_name
-    llm_model = get_llm_model_with_fallback(provider, model_name_str, True)
+    llm_model = get_llm_model_with_fallback(provider, model_name_str)
 
     response_dict: dict | None = None
     last_prompt: str = ""
@@ -491,7 +491,7 @@ async def handle_pdf_extraction(
 
     provider = pdf_extraction.llm_provider or task.llm_provider
     model_name_str = pdf_extraction.llm_model_name or task.llm_model_name
-    llm_model = get_llm_model_with_fallback(provider, model_name_str, True)
+    llm_model = get_llm_model_with_fallback(provider, model_name_str)
 
     system_instruction = "Extract the information from the PDF file and return it in the format specified by the instructions."
     response, token_usage = llm_model.get_model_response_with_structured_output(

--- a/optexity/inference/core/run_interaction.py
+++ b/optexity/inference/core/run_interaction.py
@@ -41,9 +41,7 @@ _error_handler_cache: dict[tuple, ErrorHandlerAgent] = {}
 def _get_error_handler(task: "Task") -> ErrorHandlerAgent:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _error_handler_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _error_handler_cache[cache_key] = ErrorHandlerAgent(model)
     return _error_handler_cache[cache_key]
 

--- a/optexity/inference/core/run_two_fa.py
+++ b/optexity/inference/core/run_two_fa.py
@@ -33,9 +33,7 @@ _two_fa_cache: dict[tuple, TwoFAExtraction] = {}
 def _get_two_fa_agent(task: "Task") -> TwoFAExtraction:
     cache_key = (task.llm_provider, task.llm_model_name)
     if cache_key not in _two_fa_cache:
-        model = get_llm_model_with_fallback(
-            task.llm_provider, task.llm_model_name, True
-        )
+        model = get_llm_model_with_fallback(task.llm_provider, task.llm_model_name)
         _two_fa_cache[cache_key] = TwoFAExtraction(model)
     return _two_fa_cache[cache_key]
 

--- a/optexity/inference/models/__init__.py
+++ b/optexity/inference/models/__init__.py
@@ -78,12 +78,11 @@ def get_equivalent_model(
 
 def _try_create_model(
     model_name: GeminiModels | HumanModels | OpenAIModels | AnthropicModels,
-    use_structured_output: bool,
 ) -> LLMModel | None:
     """Try to create a model. Returns instance on success, None on failure.
     Results are cached — successful models in _model_cache, failures in _failed_models.
     """
-    cache_key = (model_name, use_structured_output)
+    cache_key = model_name
 
     # Already cached
     if cache_key in _model_cache:
@@ -94,25 +93,23 @@ def _try_create_model(
         if isinstance(model_name, GeminiModels):
             from .gemini import Gemini
 
-            instance = Gemini(model_name, use_structured_output)
+            instance = Gemini(model_name)
 
         elif isinstance(model_name, OpenAIModels):
             from .openai import OpenAI
 
-            instance = OpenAI(model_name, use_structured_output)
+            instance = OpenAI(model_name)
 
         elif isinstance(model_name, AnthropicModels):
             from .anthropic import Anthropic
 
-            instance = Anthropic(model_name, use_structured_output)
+            instance = Anthropic(model_name)
 
         else:
             raise ValueError(f"Invalid model type: {model_name}")
 
         _model_cache[cache_key] = instance
-        logger.info(
-            f"Created model {model_name.value} (structured={use_structured_output})"
-        )
+        logger.info(f"Created model {model_name.value}")
         return instance
 
     except Exception as e:
@@ -122,26 +119,21 @@ def _try_create_model(
 
 def get_llm_model(
     model_name: GeminiModels | HumanModels | OpenAIModels | AnthropicModels,
-    use_structured_output: bool,
 ) -> LLMModel:
-    model = _try_create_model(model_name, use_structured_output)
+    model = _try_create_model(model_name)
     if model is not None:
         return model
-    raise ValueError(
-        f"Model {model_name.value} (structured={use_structured_output}) not available"
-    )
+    raise ValueError(f"Model {model_name.value} not available")
 
 
-def _get_first_fallback(
-    provider: str, model_name: str, use_structured_output: bool
-) -> LLMModel | None:
+def _get_first_fallback(provider: str, model_name: str) -> LLMModel | None:
     """Try fallback providers one by one, return the first that works."""
     for fallback_provider in FALLBACK_ORDER:
         if fallback_provider == provider:
             continue
         try:
             equiv = get_equivalent_model(model_name, fallback_provider)
-            fb_model = _try_create_model(equiv, use_structured_output)
+            fb_model = _try_create_model(equiv)
             if fb_model is not None:
                 logger.info(
                     f"Fallback: {provider}/{model_name} "
@@ -157,22 +149,20 @@ def _get_first_fallback(
     return None
 
 
-def get_llm_model_with_fallback(
-    provider: str, model_name: str, use_structured_output: bool
-) -> LLMModel:
+def get_llm_model_with_fallback(provider: str, model_name: str) -> LLMModel:
     """Get an LLMModel with one fallback for inference-time failures."""
     from .fallback import FallbackLLMModel
 
     model_enum = resolve_model_name(provider, model_name)
 
     # Try primary
-    primary = _try_create_model(model_enum, use_structured_output)
+    primary = _try_create_model(model_enum)
 
     if primary is not None:
         logger.info(f"Using primary model {provider}/{model_name}")
 
         # Try to add one fallback for inference-time safety
-        fallback = _get_first_fallback(provider, model_name, use_structured_output)
+        fallback = _get_first_fallback(provider, model_name)
         if fallback is not None:
             return FallbackLLMModel([primary, fallback])
         return primary
@@ -181,7 +171,7 @@ def get_llm_model_with_fallback(
     logger.warning(
         f"Primary model {provider}/{model_name} not available, trying fallbacks..."
     )
-    fallback = _get_first_fallback(provider, model_name, use_structured_output)
+    fallback = _get_first_fallback(provider, model_name)
     if fallback is not None:
         return fallback
 

--- a/optexity/inference/models/anthropic.py
+++ b/optexity/inference/models/anthropic.py
@@ -45,8 +45,8 @@ def _restore_schema_keys(obj):
 
 class Anthropic(LLMModel):
 
-    def __init__(self, model_name: AnthropicModels, use_structured_output: bool):
-        super().__init__(model_name, use_structured_output)
+    def __init__(self, model_name: AnthropicModels):
+        super().__init__(model_name)
 
         try:
             api_key = os.environ["ANTHROPIC_API_KEY"]
@@ -115,28 +115,23 @@ class Anthropic(LLMModel):
             kwargs["system"] = system_instruction
 
         try:
-            if self.use_structured_output:
-                schema = _sanitize_schema_keys(response_schema.model_json_schema())
-                kwargs["tools"] = [
-                    {
-                        "name": "structured_output",
-                        "description": "Return the structured response",
-                        "input_schema": schema,
-                    }
-                ]
-                kwargs["tool_choice"] = {"type": "tool", "name": "structured_output"}
+            schema = _sanitize_schema_keys(response_schema.model_json_schema())
+            kwargs["tools"] = [
+                {
+                    "name": "structured_output",
+                    "description": "Return the structured response",
+                    "input_schema": schema,
+                }
+            ]
+            kwargs["tool_choice"] = {"type": "tool", "name": "structured_output"}
 
-                response = self.client.messages.create(**kwargs)
+            response = self.client.messages.create(**kwargs)
 
-                for block in response.content:
-                    if block.type == "tool_use" and block.name == "structured_output":
-                        restored = _restore_schema_keys(block.input)
-                        parsed_response = response_schema.model_validate(restored)
-                        break
-            else:
-                response = self.client.messages.create(**kwargs)
-                text = response.content[0].text
-                parsed_response = self.parse_from_completion(text, response_schema)
+            for block in response.content:
+                if block.type == "tool_use" and block.name == "structured_output":
+                    restored = _restore_schema_keys(block.input)
+                    parsed_response = response_schema.model_validate(restored)
+                    break
 
             if response.usage is not None:
                 token_usage = self.get_token_usage(

--- a/optexity/inference/models/fallback.py
+++ b/optexity/inference/models/fallback.py
@@ -16,7 +16,7 @@ class FallbackLLMModel(LLMModel):
         if not models:
             raise ValueError("FallbackLLMModel requires at least one model")
         primary = models[0]
-        super().__init__(primary.model_name, primary.use_structured_output)
+        super().__init__(primary.model_name)
         self.models = models
 
     def get_model_response(

--- a/optexity/inference/models/gemini.py
+++ b/optexity/inference/models/gemini.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 class Gemini(LLMModel):
 
-    def __init__(self, model_name: GeminiModels, use_structured_output: bool):
-        super().__init__(model_name, use_structured_output)
+    def __init__(self, model_name: GeminiModels):
+        super().__init__(model_name)
 
         self.api_key = os.environ["GOOGLE_API_KEY"]
         try:
@@ -73,31 +73,20 @@ class Gemini(LLMModel):
         token_usage = TokenUsage()
 
         try:
-            if self.use_structured_output:
-                response = self.client.models.generate_content(
-                    model=self.model_name.value,
-                    contents=final_prompt,
-                    config={
-                        "response_mime_type": "application/json",
-                        "system_instruction": system_instruction,
-                        "response_json_schema": response_schema.model_json_schema(),
-                    },
-                )
+            response = self.client.models.generate_content(
+                model=self.model_name.value,
+                contents=final_prompt,
+                config={
+                    "response_mime_type": "application/json",
+                    "system_instruction": system_instruction,
+                    "response_json_schema": response_schema.model_json_schema(),
+                },
+            )
 
-                if isinstance(response.parsed, BaseModel):
-                    parsed_response = response.parsed
-                else:
-                    parsed_response = response_schema.model_validate(response.parsed)
+            if isinstance(response.parsed, BaseModel):
+                parsed_response = response.parsed
             else:
-                response = self.client.models.generate_content(
-                    model=self.model_name.value,
-                    contents=final_prompt,
-                    config={"system_instruction": system_instruction},
-                )
-
-                parsed_response: BaseModel = self.parse_from_completion(
-                    str(response.candidates[0].content.parts[0].text), response_schema
-                )
+                parsed_response = response_schema.model_validate(response.parsed)
 
             if response.usage_metadata is not None:
                 token_usage = self.get_token_usage(

--- a/optexity/inference/models/llm_model.py
+++ b/optexity/inference/models/llm_model.py
@@ -1,13 +1,11 @@
-import ast
 import logging
-import re
 import time
 from enum import Enum, unique
 from pathlib import Path
 from typing import Optional
 
 import tokencost.costs
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from optexity.schema.token_usage import TokenUsage
 
@@ -66,11 +64,9 @@ class LLMModel:
     def __init__(
         self,
         model_name: GeminiModels | HumanModels | OpenAIModels | AnthropicModels,
-        use_structured_output: bool,
     ):
 
         self.model_name = model_name
-        self.use_structured_output = use_structured_output
 
     def _get_model_response(
         self, prompt: str, system_instruction: Optional[str] = None
@@ -142,43 +138,6 @@ class LLMModel:
             + "\n"
             + last_exception
         )
-
-    def extract_json_objects(self, text):
-        stack = []  # Stack to track `{` positions
-        json_candidates = []  # Potential JSON substrings
-
-        # Iterate through the text to find balanced { }
-        for i, char in enumerate(text):
-            if char == "{":
-                stack.append(i)  # Store index of '{'
-            elif char == "}" and stack:
-                start = stack.pop()  # Get the last unmatched '{'
-                json_candidates.append(text[start : i + 1])  # Extract substring
-
-        return json_candidates
-
-    def parse_from_completion(
-        self, content: str, response_schema: type[BaseModel]
-    ) -> BaseModel:
-        patterns = [r"```json\n(.*?)\n```"]
-        json_blocks = []
-        for pattern in patterns:
-            json_blocks += re.findall(pattern, content, re.DOTALL)
-        json_blocks += self.extract_json_objects(content)
-        for block in json_blocks:
-            block = block.strip()
-            try:
-                response = response_schema.model_validate_json(block)
-                return response
-            except Exception as e:
-                try:
-                    block_dict = ast.literal_eval(block)
-                    response = response_schema.model_validate(block_dict)
-                    return response
-                except Exception as e:
-                    continue
-
-        raise ValidationError("Could not parse response from completion.")
 
     def get_token_usage(
         self,

--- a/optexity/inference/models/openai.py
+++ b/optexity/inference/models/openai.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 class OpenAI(LLMModel):
 
-    def __init__(self, model_name: OpenAIModels, use_structured_output: bool):
-        super().__init__(model_name, use_structured_output)
+    def __init__(self, model_name: OpenAIModels):
+        super().__init__(model_name)
 
         try:
             from openai import OpenAI as OpenAIClient
@@ -92,20 +92,12 @@ class OpenAI(LLMModel):
         parsed_response = None
 
         try:
-            if self.use_structured_output:
-                response = self.client.beta.chat.completions.parse(
-                    model=self.model_name.value,
-                    messages=messages,
-                    response_format=response_schema,
-                )
-                parsed_response = response.choices[0].message.parsed
-            else:
-                response = self.client.chat.completions.create(
-                    model=self.model_name.value,
-                    messages=messages,
-                )
-                content = response.choices[0].message.content
-                parsed_response = self.parse_from_completion(content, response_schema)
+            response = self.client.beta.chat.completions.parse(
+                model=self.model_name.value,
+                messages=messages,
+                response_format=response_schema,
+            )
+            parsed_response = response.choices[0].message.parsed
 
             if response.usage is not None:
                 token_usage = self.get_token_usage(


### PR DESCRIPTION
Closes #48

## Summary
`use_structured_output` was passed to `get_llm_model()` / `get_llm_model_with_fallback()` and every `LLMModel` subclass, but it was **always `True`** throughout the codebase. This removes the parameter entirely and deletes the dead code paths it gated, simplifying the interface and making it easier to add new providers.

## Changes
- Drop the `use_structured_output` parameter from `get_llm_model`, `get_llm_model_with_fallback`, `_try_create_model`, `_get_first_fallback`, the `LLMModel` base constructor, and the `Gemini` / `OpenAI` / `Anthropic` / `FallbackLLMModel` constructors. The model cache key is now just the model enum.
- Collapse the always-taken `if self.use_structured_output:` branch in each provider's `_get_model_response_with_structured_output()`, removing the dead `else` (non-structured) branch.
- Remove the now-unused `parse_from_completion()` and `extract_json_objects()` helpers (only the dead branches called them) and their now-unused `ast` / `re` / `ValidationError` imports.
- Update all 8 call sites to drop the trailing `True` argument.

## No behavior change
The structured-output path was the only one ever exercised (every caller passed `True`), so this is a pure simplification — no runtime behavior changes.

## Note
This supersedes the stale PR #49 (same issue, no activity since Feb 2026) with a clean, rebased implementation.

## Validation
- `optexity.inference.models` imports cleanly; verified the updated signatures (`get_llm_model(model_name)`, `get_llm_model_with_fallback(provider, model_name)`, `LLMModel.__init__(self, model_name)`) and that `parse_from_completion` is gone.
- `ruff check` on the changed files introduces **no new findings** (net −2: removed two unused-variable `except ... as e` cases along with the dead branches).
- Confirmed no remaining references to `use_structured_output` / `parse_from_completion` / `extract_json_objects` anywhere in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)