### PR TITLE
feat(extraction): add api_call extraction runtime

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -260,13 +260,17 @@
             "id": "docs-action-types-extraction-action",
             "path": "docs/action-types/extraction-action.mdx",
             "title": "Extraction Actions",
-            "summary": "Comprehensive guide to all extraction action types: llm (AI-based page extraction), locator (Playwright-based with LLM fallback), network_call (capture AJAX/API responses), screenshot (save visual snapshot), state (URL/title/cookies/storage), and two_fa_action (2FA code extraction). Each type includes its JSON schema, properties table, and when-to-use guidance. Also covers timing defaults and source selection for LLM extraction.",
-            "gist": "All extraction types (llm, locator, network_call, screenshot, state, 2FA) with schemas and when to use each.",
+            "summary": "Comprehensive guide to all extraction action types: llm (AI-based page extraction), locator (Playwright-based with LLM fallback), network_call (capture AJAX/API responses), api_call (make outbound REST API calls with polling and dot-path response variables), screenshot (save visual snapshot), state (URL/title/cookies/storage), and two_fa_action (2FA code extraction). Each type includes its JSON schema, properties table, and when-to-use guidance. Also covers timing defaults and source selection for LLM extraction.",
+            "gist": "All extraction types (llm, locator, network_call, api_call, screenshot, state, 2FA) with schemas and when to use each.",
             "keywords": [
                 "extraction",
                 "llm extraction",
                 "locator extraction",
                 "network_call",
+                "api_call",
+                "REST API call",
+                "polling",
+                "webhook",
                 "screenshot",
                 "state extraction",
                 "cookies",
@@ -276,7 +280,7 @@
                 "extraction_instructions"
             ],
             "document_type": "guide",
-            "tags": ["action-types", "extraction", "data", "scraping", "2FA"],
+            "tags": ["action-types", "extraction", "data", "scraping", "api", "2FA"],
             "relationships": {
                 "depends_on": ["docs-building-automations-action-node"],
                 "references": [
@@ -308,14 +312,15 @@
                     "llm",
                     "locator",
                     "network_call",
+                    "api_call",
                     "state",
                     "two_fa_action",
                     "extraction_format"
                 ]
             },
             "reading_priority": 2,
-            "when_to_use": "Select when the query is about extracting data from web pages, capturing API responses, taking screenshots, reading cookies/storage, or the extraction action schema.",
-            "embedding_hint": "extract data web page llm network_call screenshot state cookies 2FA output_variable_name"
+            "when_to_use": "Select when the query is about extracting data from web pages, capturing API responses, calling external REST APIs or webhooks, polling async endpoints, taking screenshots, reading cookies/storage, or the extraction action schema.",
+            "embedding_hint": "extract data web page llm network_call api_call REST API webhook polling screenshot state cookies 2FA output_variable_name"
         },
         {
             "id": "docs-action-types-interaction-action",

--- a/docs/docs/action-types/extraction-action.mdx
+++ b/docs/docs/action-types/extraction-action.mdx
@@ -12,6 +12,7 @@ Extraction actions capture data from web pages during automation—essential for
 | `llm` | AI-powered structured data extraction | Tables, forms, text content |
 | `locator` | Extract text directly via Playwright locator | Single values, fast extraction, no LLM tokens |
 | `network_call` | Capture API/AJAX responses | API data, JSON responses |
+| `api_call` | Call an external REST API directly | Webhooks, triggering jobs, polling for async results |
 | `screenshot` | Save visual snapshot | Receipts, proofs, visual records |
 | `state` | Capture page state (URL, title, storage, cookies) | Debugging auth, navigation validation |
 | `two_fa_action` | Wait for and extract 2FA code | 2FA codes |
@@ -212,6 +213,104 @@ Capture data from API requests and responses:
 | `download_from` | `"request" \| "response"` | `None` | Download as file |
 | `download_filename` | `str \| None` | Auto-generated | Filename for download |
 
+<Tip>
+Use `network_call` to *intercept* requests the page already makes. Use `api_call` (below) to *initiate* your own HTTP request to any external endpoint.
+</Tip>
+
+---
+
+## API Call Extraction
+
+Make an outbound REST API call directly from the automation—useful for hitting webhooks, triggering backend jobs, enriching data from a third-party service, or polling an async endpoint until it's ready. The full response is stored as a variable for use in later actions.
+
+```json
+{
+  "extraction_action": {
+    "api_call": {
+      "url": "https://api.example.com/v1/orders",
+      "method": "GET"
+    }
+  }
+}
+```
+
+### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `url` | `str` | Required | Endpoint to call |
+| `method` | `"GET" \| "POST" \| "PUT" \| "PATCH" \| "DELETE"` | `"GET"` | HTTP method |
+| `headers` | `dict[str, str]` | `{}` | Request headers |
+| `body` | `dict \| str \| None` | `None` | Request body. A `dict` is sent as JSON; a `str` is sent as raw content |
+| `query_params` | `dict[str, str]` | `{}` | URL query parameters |
+| `output_variable_names` | `list[str]` | `["api_result"]` | Variable name(s) to store the response under |
+| `timeout` | `float` | `30.0` | Request timeout in seconds |
+| `poll_condition` | `str \| None` | `None` | Expression to re-poll until satisfied (see [Polling](#polling)) |
+| `poll_interval` | `float` | `5.0` | Seconds to wait between poll attempts |
+| `max_poll_attempts` | `int` | `10` | Maximum number of poll attempts |
+
+### Response Shape
+
+The stored variable holds a dict with the following keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `status_code` | `int \| null` | HTTP status code (`null` on a connection error or timeout) |
+| `headers` | `dict[str, str]` | Response headers |
+| `body` | `any` | Parsed JSON if the response is JSON, otherwise the raw text |
+| `error` | `str` | Present only on failure—`"timeout"` or `"http_error"` |
+
+### Using the Response
+
+Reference fields of the response in later actions with dot-path syntax: `{var.field}`, `{var.nested.field}`, and `{var.array[0].field}`. Both object keys and array indices are supported.
+
+```json
+{
+  "extraction_action": {
+    "api_call": {
+      "url": "https://api.example.com/v1/customers",
+      "method": "POST",
+      "headers": { "Authorization": "Bearer {api_token}" },
+      "body": { "email": "{customer_email}" },
+      "output_variable_names": ["create_result"]
+    }
+  }
+}
+```
+
+After this action, `{create_result.body.id}` resolves to the new customer's ID, and `{create_result.status_code}` resolves to `201`.
+
+<Info>
+Dot-path resolution (`{var.field}`) applies only to dict-valued variables such as API responses. The existing list-indexing format `{var[0]}` from `llm` extraction is unaffected.
+</Info>
+
+### Polling
+
+For asynchronous endpoints, set `poll_condition` to keep re-requesting until the condition is met (or `max_poll_attempts` is reached). The condition is a Python-style boolean expression evaluated against the response dict, supporting both top-level keys and dot-paths:
+
+```json
+{
+  "extraction_action": {
+    "api_call": {
+      "url": "https://api.example.com/v1/jobs/{job_id}",
+      "poll_condition": "body.status == 'completed'",
+      "poll_interval": 10.0,
+      "max_poll_attempts": 30
+    }
+  }
+}
+```
+
+Example conditions:
+
+| Condition | Meaning |
+|-----------|---------|
+| `status_code == 200` | Stop once the request returns HTTP 200 |
+| `body.status == 'completed'` | Stop once the response body's `status` field is `"completed"` |
+| `body.progress >= 100` | Stop once `progress` reaches 100 |
+
+If the condition is never met within `max_poll_attempts`, the last response is stored and the automation continues.
+
 ---
 
 ## Screenshot Extraction
@@ -330,6 +429,8 @@ Override if needed:
 | Extract a single known element | `locator` |
 | Extract with locator + LLM fallback | `locator` with `extraction_instructions` |
 | Charts, images, visual content | `llm` with `screenshot` |
-| Intercept API data | `network_call` |
+| Intercept API data the page requests | `network_call` |
+| Call an external API / webhook directly | `api_call` |
+| Poll an async endpoint until ready | `api_call` with `poll_condition` |
 | Visual proof/documentation | `screenshot` |
 | Validate navigation | `state` |

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -35,6 +35,7 @@ from optexity.inference.core.run_interaction import (
 )
 from optexity.inference.core.run_misc import run_fail_state_action, run_sleep_action
 from optexity.inference.core.run_python_script import run_python_script_action
+from optexity.inference.core.variable_resolver import resolve_api_variables_in_node
 from optexity.inference.infra.browser import Browser
 from optexity.schema.actions.interaction_action import DownloadUrlAsPdfAction
 from optexity.schema.automation import ActionNode, ForLoopNode, IfElseNode
@@ -320,6 +321,7 @@ async def run_action_node(
         task.secure_parameters, task.workspace_id, task.api_key
     )
     await action_node.replace_variables(memory.variables.generated_variables)
+    resolve_api_variables_in_node(action_node, memory.variables.generated_variables)
 
     # ## TODO: optimize this by taking screenshot and axtree only if needed
     # browser_state_summary = await browser.get_browser_state_summary()

--- a/optexity/inference/core/run_extraction.py
+++ b/optexity/inference/core/run_extraction.py
@@ -12,6 +12,7 @@ from optexity.inference.infra.browser import Browser
 from optexity.inference.infra.browser_health import fetch_browser_state_for_classifier
 from optexity.inference.models import get_llm_model_with_fallback
 from optexity.schema.actions.extraction_action import (
+    APICallExtraction,
     ExtractionAction,
     LLMExtraction,
     LocatorExtraction,
@@ -31,6 +32,7 @@ from optexity.schema.memory import (
     ScreenshotData,
 )
 from optexity.schema.task import Task
+from optexity.utils.http import make_api_request
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +108,12 @@ async def run_extraction_action(
             memory,
             browser,
             task,
+            extraction_action.unique_identifier,
+        )
+    elif extraction_action.api_call:
+        await handle_api_call_extraction(
+            extraction_action.api_call,
+            memory,
             extraction_action.unique_identifier,
         )
 
@@ -515,3 +523,74 @@ async def handle_pdf_extraction(
     )
 
     return output_data
+
+
+async def handle_api_call_extraction(
+    api_call_extraction: APICallExtraction,
+    memory: Memory,
+    unique_identifier: str | None = None,
+):
+    """Execute an external REST API call with optional polling and store the response."""
+    from optexity.inference.core.variable_resolver import evaluate_poll_condition
+
+    logger.info(f"API call: {api_call_extraction.method} {api_call_extraction.url}")
+
+    result = await make_api_request(
+        url=api_call_extraction.url,
+        method=api_call_extraction.method,
+        headers=api_call_extraction.headers,
+        body=api_call_extraction.body,
+        query_params=api_call_extraction.query_params,
+        timeout=api_call_extraction.timeout,
+    )
+    logger.info(
+        f"API response: status_code={result.get('status_code')}, body={result.get('body')}"
+    )
+
+    if api_call_extraction.poll_condition and "error" not in result:
+        for attempt in range(1, api_call_extraction.max_poll_attempts):
+            if evaluate_poll_condition(api_call_extraction.poll_condition, result):
+                logger.info(
+                    f"Poll condition met on attempt {attempt}: {api_call_extraction.poll_condition}"
+                )
+                break
+
+            logger.info(
+                f"Poll attempt {attempt}/{api_call_extraction.max_poll_attempts} "
+                f"- condition not met, waiting {api_call_extraction.poll_interval}s"
+            )
+            await asyncio.sleep(api_call_extraction.poll_interval)
+            result = await make_api_request(
+                url=api_call_extraction.url,
+                method=api_call_extraction.method,
+                headers=api_call_extraction.headers,
+                body=api_call_extraction.body,
+                query_params=api_call_extraction.query_params,
+                timeout=api_call_extraction.timeout,
+            )
+            logger.info(
+                f"Poll attempt {attempt} response: status_code={result.get('status_code')}, body={result.get('body')}"
+            )
+
+            if "error" in result:
+                logger.error(
+                    f"Poll attempt {attempt} failed with error: {result['error']}"
+                )
+                break
+        else:
+            logger.warning(
+                f"Poll condition not met after {api_call_extraction.max_poll_attempts} attempts, "
+                f"storing last response"
+            )
+
+    for var_name in api_call_extraction.output_variable_names:
+        memory.variables.generated_variables[var_name] = result
+
+    memory.variables.output_data.append(
+        OutputData(unique_identifier=unique_identifier, json_data=result)
+    )
+
+    logger.info(
+        f"API call result stored in {api_call_extraction.output_variable_names}, "
+        f"status_code={result.get('status_code')}"
+    )

--- a/optexity/inference/core/variable_resolver.py
+++ b/optexity/inference/core/variable_resolver.py
@@ -1,0 +1,139 @@
+"""Dot-path variable resolver for API call response dicts.
+
+Resolves patterns like {var.field}, {var.nested.field}, {var.array[0].field}
+in action node string fields. Only applies to dict-valued generated variables
+(e.g., API call responses). Does NOT interfere with the existing {key[index]}
+replacement system.
+"""
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Matches {identifier.path} where path must start with a dot-segment.
+# This ensures {key[0]} (existing format) is NEVER matched.
+# Examples that match:  {api_result.status}, {api_result.data[0].name}
+# Examples that don't:  {key[0]}, {key[index]}
+_API_VAR_PATTERN = re.compile(r"\{(\w+)(\.\w+(?:\.\w+|\[\d+\])*)\}")
+
+
+def _parse_path_segments(path: str) -> list[tuple[str, str | int]]:
+    """Parse '.foo.bar[0].baz' into [('attr','foo'), ('attr','bar'), ('index',0), ('attr','baz')]"""
+    result = []
+    for part in re.finditer(r"\.(\w+)|\[(\d+)\]", path):
+        if part.group(1) is not None:
+            result.append(("attr", part.group(1)))
+        else:
+            result.append(("index", int(part.group(2))))
+    return result
+
+
+def _resolve_path(data: Any, path_str: str) -> Any:
+    """Walk a dict/list structure following a dot/bracket path.
+
+    Returns the resolved value, or None if the path doesn't exist.
+    """
+    segments = _parse_path_segments(path_str)
+    current = data
+    for seg_type, seg_value in segments:
+        if seg_type == "attr":
+            if isinstance(current, dict) and seg_value in current:
+                current = current[seg_value]
+            else:
+                return None
+        elif seg_type == "index":
+            if isinstance(current, (list, tuple)) and seg_value < len(current):
+                current = current[seg_value]
+            else:
+                return None
+    return current
+
+
+def resolve_api_variables_in_node(action_node, generated_variables: dict) -> None:
+    """Resolve all {var.path} patterns in an action node using dict-valued generated variables.
+
+    Serializes the node to JSON to discover patterns, then uses the existing
+    action_node.replace() infrastructure to perform substitutions.
+    """
+    node_json = action_node.model_dump_json()
+
+    # Deduplicate patterns to avoid redundant replacements
+    seen = set()
+    for match in _API_VAR_PATTERN.finditer(node_json):
+        full_pattern = match.group(0)
+        if full_pattern in seen:
+            continue
+        seen.add(full_pattern)
+
+        var_name = match.group(1)
+        path_str = match.group(2)
+
+        if var_name not in generated_variables:
+            continue
+
+        data = generated_variables[var_name]
+        if not isinstance(data, dict):
+            continue
+
+        resolved = _resolve_path(data, path_str)
+        if resolved is None:
+            continue
+
+        if isinstance(resolved, (dict, list)):
+            replacement = json.dumps(resolved)
+        else:
+            replacement = str(resolved)
+
+        action_node.replace(full_pattern, replacement)
+
+
+def evaluate_poll_condition(condition: str, response: dict) -> bool:
+    """Evaluate a poll condition expression against an API response dict.
+
+    Supports both top-level keys and dot-path syntax:
+        "status_code == 200"
+        "body.status == 'completed'"
+        "body.progress >= 100"
+
+    All identifiers that match response keys (with or without dot-paths)
+    are resolved before evaluation.
+    """
+
+    def _resolve_identifier(match: re.Match) -> str:
+        """Replace an identifier or dot-path with its resolved value."""
+        full_path = match.group(0)
+        segments = full_path.split(".")
+        root = segments[0]
+
+        # Only resolve if root is a key in the response
+        if root not in response:
+            return full_path
+
+        if len(segments) == 1:
+            # Top-level key like "status_code"
+            resolved = response[root]
+        else:
+            # Dot-path like "body.status"
+            resolved = _resolve_path(response, "." + full_path)
+
+        if resolved is None:
+            return "None"
+        if isinstance(resolved, str):
+            return repr(resolved)
+        if isinstance(resolved, (dict, list)):
+            return repr(resolved)
+        return str(resolved)
+
+    # Match identifiers: standalone words or dot-paths, optionally with [N]
+    resolved_condition = re.sub(
+        r"\b([a-zA-Z_]\w*(?:\.\w+)*(?:\[\d+\])?)\b", _resolve_identifier, condition
+    )
+
+    try:
+        return bool(eval(resolved_condition))  # noqa: S307
+    except Exception as e:
+        logger.warning(f"Poll condition eval failed: '{resolved_condition}' -> {e}")
+        return False

--- a/optexity/utils/http.py
+++ b/optexity/utils/http.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Any, Literal
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+async def make_api_request(
+    url: str,
+    method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = "GET",
+    headers: dict[str, str] | None = None,
+    body: dict | str | None = None,
+    query_params: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Make an HTTP request and return a result dict with status_code, headers, and body."""
+    try:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            kwargs: dict[str, Any] = {
+                "method": method,
+                "url": url,
+                "headers": headers or {},
+                "params": query_params or {},
+                "timeout": timeout,
+            }
+
+            if body is not None:
+                if isinstance(body, dict):
+                    kwargs["json"] = body
+                else:
+                    kwargs["content"] = body
+
+            response = await client.request(**kwargs)
+
+        try:
+            response_body = response.json()
+        except Exception:
+            response_body = response.text
+
+        return {
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "body": response_body,
+        }
+
+    except httpx.TimeoutException as e:
+        logger.error(f"API call timed out: {url} - {e}")
+        return {
+            "error": "timeout",
+            "message": str(e),
+            "status_code": None,
+            "body": None,
+            "headers": {},
+        }
+
+    except httpx.HTTPError as e:
+        logger.error(f"API call HTTP error: {url} - {e}")
+        return {
+            "error": "http_error",
+            "message": str(e),
+            "status_code": None,
+            "body": None,
+            "headers": {},
+        }


### PR DESCRIPTION
Adds the runtime/execution layer for the api_call extraction action. The schema (APICallExtraction, deep_replace, ActionNode non-list skip) already landed on main via earlier schema-sync PRs; this completes the feature by porting the execution code from ui_agents_prince:

- optexity/utils/http.py: make_api_request HTTP helper
- optexity/inference/core/variable_resolver.py: dot-path {var.field} resolution and poll-condition evaluation
- run_extraction.py: handle_api_call_extraction + dispatch branch, with optional polling
- run_automation.py: resolve api response variables in action nodes

Ports commits dbbd33c (api_call extraction action) and c8cff8b (api_call polling fix) cleanly onto main, excluding unrelated later changes to variable_resolver.py (forloop dynamic index, 8f84013).