### PR TITLE
Add max_parallelism/max_unique_logins to InferenceRequest and Task

### DIFF
--- a/optexity/schema/inference.py
+++ b/optexity/schema/inference.py
@@ -14,8 +14,12 @@ class InferenceRequest(BaseModel):
     max_timeout_in_minutes: int = 10
     use_proxy: bool = False
     is_dedicated: bool = (
-        False  ## Only used in local mode. For cloud mode, the task is dedicated is defined on dashboard.
+        False  ## Opt into dedicated mode per-request. In cloud mode a dedicated_service DB row (admin policy) takes precedence over this flag.
     )
+    # Dedicated limits used only when is_dedicated is true and no DB policy row
+    # exists. max_parallelism is clamped server-side (see DEDICATED_MAX_REQUEST_PARALLELISM).
+    max_parallelism: int = 1
+    max_unique_logins: int = 1
 
     @model_validator(mode="after")
     def validate_use_proxy(self):

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -119,6 +119,11 @@ class Task(BaseModel):
     api_key: str
     callback_url: CallbackUrl | None = None
     is_dedicated: bool = False
+    # Dedicated limits carried with the task when is_dedicated is set via the
+    # request (no DB policy row). Ignored for non-dedicated tasks and when a
+    # dedicated_service DB row governs the service.
+    max_parallelism: int = 1
+    max_unique_logins: int = 1
     company_id: CompanyID
     llm_provider: Literal["gemini", "anthropic", "openai"] = "gemini"
     llm_model_name: str = "gemini-2.5-flash"


### PR DESCRIPTION
Carry request-driven dedicated limits (defaults 1,1) so cloud mode can honor per-request dedicated config. is_dedicated already existed; clarify its docstring to note a DB policy row takes precedence over the request flag in cloud mode.