### PR TITLE
Replace max_unique_logins with per_login_parallelism on dedicated req…

### DIFF
--- a/optexity/schema/inference.py
+++ b/optexity/schema/inference.py
@@ -17,9 +17,11 @@ class InferenceRequest(BaseModel):
         False  ## Opt into dedicated mode per-request. In cloud mode a dedicated_service DB row (admin policy) takes precedence over this flag.
     )
     # Dedicated limits used only when is_dedicated is true and no DB policy row
-    # exists. max_parallelism is clamped server-side (see DEDICATED_MAX_REQUEST_PARALLELISM).
+    # exists. max_parallelism is the service-wide cap (clamped server-side, see
+    # DEDICATED_MAX_REQUEST_PARALLELISM); per_login_parallelism is how many
+    # containers a single login may use before its tasks round-robin onto them.
     max_parallelism: int = 1
-    max_unique_logins: int = 1
+    per_login_parallelism: int = 1
 
     @model_validator(mode="after")
     def validate_use_proxy(self):

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -123,7 +123,7 @@ class Task(BaseModel):
     # request (no DB policy row). Ignored for non-dedicated tasks and when a
     # dedicated_service DB row governs the service.
     max_parallelism: int = 1
-    max_unique_logins: int = 1
+    per_login_parallelism: int = 1
     company_id: CompanyID
     llm_provider: Literal["gemini", "anthropic", "openai"] = "gemini"
     llm_model_name: str = "gemini-2.5-flash"


### PR DESCRIPTION
…uests

per_login_parallelism (how many containers a single login may use before its tasks round-robin) is now provided directly instead of being derived from max_parallelism / max_unique_logins. Callers no longer have to pre-declare a login count. Defaults to 1.