### PR TITLE
feat: assert_locator_node outputs boolean variable; harden None subst…

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -237,21 +237,19 @@
             "id": "docs-action-types-assertion-action",
             "path": "docs/action-types/assertion-action.mdx",
             "title": "Assert Locator Node",
-            "summary": "Documents assert_locator_node — a control-flow node that branches on Playwright locator visibility. Covers the to_be_visible and to_be_hidden assertions, timeout, if_nodes, else_nodes, variable substitution in the locator, and when to prefer assert_locator_node over if_else_node. Includes examples for skipping optional elements, waiting for spinners to disappear, and dynamic locators.",
-            "gist": "Branch on element visibility via Playwright locator — no LLM, no extraction variable needed.",
+            "summary": "Documents assert_locator_node — a node that checks Playwright locator visibility and stores the result as a boolean in output_variable_name. Covers the to_be_visible and to_be_hidden assertions, timeout, output_variable_name, variable substitution in the locator, and how to branch on the stored boolean with a following if_else_node. Includes examples for dismissing elements only when present, waiting for spinners to disappear, and dynamic locators.",
+            "gist": "Check element visibility via Playwright locator and store it as a boolean variable — no LLM, no extraction needed.",
             "keywords": [
                 "assert_locator_node",
                 "locator assertion",
                 "to_be_visible",
                 "to_be_hidden",
-                "conditional",
+                "boolean variable",
+                "output_variable_name",
                 "element visibility",
                 "optional element",
                 "Playwright",
-                "if_nodes",
-                "else_nodes",
-                "timeout",
-                "branching"
+                "timeout"
             ],
             "document_type": "guide",
             "tags": ["building-automations", "control-flow", "assertion", "locator", "Playwright"],
@@ -264,7 +262,7 @@
                     },
                     {
                         "doc_id": "docs-building-automations-if-else-node",
-                        "context": "if_else_node is the alternative when branching on extracted values rather than raw visibility."
+                        "context": "if_else_node consumes the boolean produced by assert_locator_node to branch on element visibility."
                     }
                 ],
                 "referenced_by": [
@@ -281,7 +279,7 @@
             },
             "reading_priority": 2,
             "when_to_use": "Select when the query is about checking element presence without an extraction step, to_be_visible / to_be_hidden assertions, handling optional page elements, or the assert_locator_node schema.",
-            "embedding_hint": "assert locator node element visibility to_be_visible to_be_hidden conditional branch Playwright optional element"
+            "embedding_hint": "assert locator node element visibility to_be_visible to_be_hidden boolean variable output_variable_name Playwright optional element"
         },
         {
             "id": "docs-action-types-extraction-action",

--- a/docs/docs/action-types/assertion-action.mdx
+++ b/docs/docs/action-types/assertion-action.mdx
@@ -1,11 +1,11 @@
 ---
 title: Assert Locator Node
-description: Branch on Playwright locator visibility — run different steps depending on whether an element is visible or hidden
+description: Check Playwright locator visibility and store the result as a boolean variable
 ---
 
-Use `assert_locator_node` to branch your automation based on whether a specific element is present on the page. It evaluates a Playwright locator within a timeout and executes `if_nodes` if the assertion passes, or `else_nodes` if it does not.
+Use `assert_locator_node` to check whether a specific element is present on the page and store the result. It evaluates a Playwright locator within a timeout and writes a boolean into `output_variable_name` (`true` if the assertion passes, `false` if it does not). You then branch on that variable with an [`if_else_node`](/docs/building-automations/if-else-node).
 
-This is the lowest-overhead way to handle optional elements—no LLM call, no extraction variable, just a direct visibility check.
+This is the lowest-overhead way to capture element presence—no LLM call, no extraction step, just a direct visibility check that becomes a reusable variable.
 
 ## Structure
 
@@ -14,20 +14,12 @@ This is the lowest-overhead way to handle optional elements—no LLM call, no ex
   "type": "assert_locator_node",
   "locator": "get_by_role(\"alert\", name=\"Error\")",
   "assertion": "to_be_visible",
-  "timeout": 5.0,
-  "if_nodes": [
-    {
-      "type": "action_node",
-      "interaction_action": {
-        "click_element": {
-          "command": "get_by_role(\"button\", name=\"Dismiss\")"
-        }
-      }
-    }
-  ],
-  "else_nodes": []
+  "output_variable_name": "error_visible",
+  "timeout": 5.0
 }
 ```
+
+The node above stores `error_visible = [true]` or `error_visible = [false]`. Reference it later as `{error_visible[0]}`.
 
 ## Properties
 
@@ -36,78 +28,91 @@ This is the lowest-overhead way to handle optional elements—no LLM call, no ex
 | `type` | `"assert_locator_node"` | Required | Node discriminator |
 | `locator` | `str` | Required | Playwright locator command (`page.<locator>` style) |
 | `assertion` | `"to_be_visible" \| "to_be_hidden"` | Required | Condition to test |
+| `output_variable_name` | `str` | Required | Variable to store the boolean result, as a single-element list (e.g. `[true]`) |
 | `timeout` | `float` | `5.0` | Seconds to wait for the assertion before treating it as failed |
-| `if_nodes` | `list[node]` | `[]` | Nodes to run when the assertion **passes** |
-| `else_nodes` | `list[node]` | `[]` | Nodes to run when the assertion **fails** (times out) |
 
-Both `if_nodes` and `else_nodes` accept any node type: `action_node`, `if_else_node`, `for_loop_node`, or nested `assert_locator_node`.
+The result is stored as a single-element list, matching the convention used by other variables, so you reference it with index `[0]` (e.g. `{error_visible[0]}`).
 
 ## Assertions
 
-| Assertion | Passes when |
-|-----------|-------------|
+| Assertion | Result is `true` when |
+|-----------|-----------------------|
 | `to_be_visible` | The element exists in the DOM and is visible within `timeout` seconds |
 | `to_be_hidden` | The element is absent or hidden within `timeout` seconds |
 
-If the assertion does not pass within `timeout`, `else_nodes` run (no error is raised).
+If the assertion does not pass within `timeout`, the variable is set to `false` (no error is raised). If the locator does not resolve at all, the result is also `false`.
 
 ## Examples
 
-### Skip a step when an element is absent
+### Dismiss an element only when it appears
 
-Check whether a "Cookie Consent" banner is visible before trying to dismiss it:
+Check whether an error alert is visible, then dismiss it with a following `if_else_node`:
 
 ```json
-{
-  "type": "assert_locator_node",
-  "locator": "get_by_role(\"dialog\", name=\"Cookie Consent\")",
-  "assertion": "to_be_visible",
-  "timeout": 3.0,
-  "if_nodes": [
-    {
-      "type": "action_node",
-      "interaction_action": {
-        "click_element": {
-          "command": "get_by_role(\"button\", name=\"Accept All\")"
+[
+  {
+    "type": "assert_locator_node",
+    "locator": "get_by_role(\"alert\", name=\"Error\")",
+    "assertion": "to_be_visible",
+    "output_variable_name": "error_visible",
+    "timeout": 5.0
+  },
+  {
+    "type": "if_else_node",
+    "condition": "{error_visible[0]}",
+    "if_nodes": [
+      {
+        "type": "action_node",
+        "interaction_action": {
+          "click_element": {
+            "command": "get_by_role(\"button\", name=\"Dismiss\")"
+          }
         }
       }
-    }
-  ],
-  "else_nodes": []
-}
+    ],
+    "else_nodes": []
+  }
+]
 ```
 
-### Assert an element is hidden before proceeding
+### Wait for a spinner to disappear, then branch
 
-Wait up to 10 seconds for a loading spinner to disappear:
+Wait up to 10 seconds for a loading spinner to be hidden, then submit or fail:
 
 ```json
-{
-  "type": "assert_locator_node",
-  "locator": "get_by_test_id(\"loading-spinner\")",
-  "assertion": "to_be_hidden",
-  "timeout": 10.0,
-  "if_nodes": [
-    {
-      "type": "action_node",
-      "interaction_action": {
-        "click_element": {
-          "command": "get_by_role(\"button\", name=\"Submit\")"
+[
+  {
+    "type": "assert_locator_node",
+    "locator": "get_by_test_id(\"loading-spinner\")",
+    "assertion": "to_be_hidden",
+    "output_variable_name": "spinner_gone",
+    "timeout": 10.0
+  },
+  {
+    "type": "if_else_node",
+    "condition": "{spinner_gone[0]}",
+    "if_nodes": [
+      {
+        "type": "action_node",
+        "interaction_action": {
+          "click_element": {
+            "command": "get_by_role(\"button\", name=\"Submit\")"
+          }
         }
       }
-    }
-  ],
-  "else_nodes": [
-    {
-      "type": "action_node",
-      "misc_action": {
-        "fail_state": {
-          "message": "Loading spinner did not disappear within 10 seconds"
+    ],
+    "else_nodes": [
+      {
+        "type": "action_node",
+        "misc_action": {
+          "fail_state": {
+            "message": "Loading spinner did not disappear within 10 seconds"
+          }
         }
       }
-    }
-  ]
-}
+    ]
+  }
+]
 ```
 
 ### Variable substitution in the locator
@@ -119,9 +124,8 @@ Wait up to 10 seconds for a loading spinner to disappear:
   "type": "assert_locator_node",
   "locator": "get_by_text(\"{order_id[0]}\")",
   "assertion": "to_be_visible",
-  "timeout": 5.0,
-  "if_nodes": [ ... ],
-  "else_nodes": [ ... ]
+  "output_variable_name": "order_found",
+  "timeout": 5.0
 }
 ```
 
@@ -129,12 +133,13 @@ Wait up to 10 seconds for a loading spinner to disappear:
 
 | | `assert_locator_node` | `if_else_node` |
 |---|---|---|
+| **Role** | Captures element visibility as a boolean variable | Branches on a Python expression over a variable |
 | **Condition** | Playwright locator visibility | Python expression on a variable |
-| **Requires extraction?** | No | Yes — needs an `extraction_action` with `output_variable_names` first |
-| **Cost** | Zero (no LLM) | Zero (expression eval) + cost of extraction |
-| **Best for** | Element present/absent checks | Comparing extracted values, complex logic |
+| **Requires extraction?** | No | Yes — needs a variable to branch on (e.g. from `assert_locator_node` or an `extraction_action`) |
+| **Cost** | Zero (no LLM) | Zero (expression eval) |
+| **Best for** | Element present/absent checks | Acting on a captured boolean or comparing extracted values |
 
-Use `assert_locator_node` when you only need to know if something is on the page. Use `if_else_node` when you need to compare the *content* of what was extracted.
+`assert_locator_node` produces the boolean; `if_else_node` consumes it. Pair them to run steps conditionally on element presence, or use the variable in any later condition.
 
 ## Locator Syntax
 

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -618,7 +618,7 @@ async def handle_assert_locator_node(
     full_automation.append(assert_node.model_dump())
     logger.debug(
         f"Handling assert locator node {assert_node.locator} ({assert_node.assertion}) "
-        f"with {len(assert_node.if_nodes)} if-nodes and {len(assert_node.else_nodes)} else-nodes"
+        f"-> {assert_node.output_variable_name}"
     )
 
     locator = await browser.get_locator_from_command(assert_node.locator)
@@ -648,12 +648,13 @@ async def handle_assert_locator_node(
                 f"failed: {type(e).__name__}"
             )
 
-    branch = assert_node.if_nodes if assertion_passed else assert_node.else_nodes
+    memory.variables.generated_variables[assert_node.output_variable_name] = [
+        assertion_passed
+    ]
     logger.debug(
-        f"Assert locator result={assertion_passed}; running "
-        f"{'if' if assertion_passed else 'else'} branch ({len(branch)} nodes)"
+        f"Assert locator result={assertion_passed}; stored in "
+        f"{assert_node.output_variable_name!r}"
     )
-    await _run_nodes(branch, task, memory, browser, full_automation)
     memory.update_system_info()
 
 

--- a/optexity/inference/core/run_extraction.py
+++ b/optexity/inference/core/run_extraction.py
@@ -58,15 +58,14 @@ def _enforce_extraction_not_null(
 ) -> None:
     """Fail the automation if the extraction produced null value(s).
 
-    Only runs when ``allow_none`` is False (the default). The policy for "null"
-    differs by extraction type:
+    Only runs when ``allow_none`` is False (the default). It applies a deep null
+    check over the variables this node wrote, so any null anywhere in the
+    extracted value (top-level, list element, or nested field) fails.
 
-    - ``api_call``: request-failure semantics — fail only if the call errored or
-      returned no status code. Nulls *inside* an otherwise-successful response
-      body are allowed (they may be legitimate API data).
-    - everything else: a deep null check over the variables this node wrote, so
-      any null anywhere in the extracted value (top-level, list element, or
-      nested field) fails.
+    ``api_call`` is intentionally exempt: prod tolerates errored / null api
+    responses (they are stored and can be branched on), so failing here would
+    change current behavior. The response dict still carries ``status_code`` /
+    ``error`` for the automation to handle explicitly.
 
     Variables are identified by identity diff against ``vars_before`` so only the
     values (re)written by this extraction node are inspected — making this safe
@@ -75,16 +74,6 @@ def _enforce_extraction_not_null(
     gv = memory.variables.generated_variables
 
     if extraction_action.api_call is not None:
-        for var_name in extraction_action.api_call.output_variable_names:
-            result = gv.get(var_name)
-            if isinstance(result, dict) and (
-                result.get("error") is not None or result.get("status_code") is None
-            ):
-                raise ValueError(
-                    f"api_call extraction {var_name!r} failed "
-                    f"(status_code={result.get('status_code')}, "
-                    f"error={result.get('error')!r}) and allow_none is False"
-                )
         return
 
     for key, value in gv.items():

--- a/optexity/inference/core/run_extraction.py
+++ b/optexity/inference/core/run_extraction.py
@@ -53,12 +53,58 @@ def _extraction_response_contains_null(obj) -> bool:
     return False
 
 
+def _enforce_extraction_not_null(
+    extraction_action: ExtractionAction, memory: Memory, vars_before: dict
+) -> None:
+    """Fail the automation if the extraction produced null value(s).
+
+    Only runs when ``allow_none`` is False (the default). The policy for "null"
+    differs by extraction type:
+
+    - ``api_call``: request-failure semantics — fail only if the call errored or
+      returned no status code. Nulls *inside* an otherwise-successful response
+      body are allowed (they may be legitimate API data).
+    - everything else: a deep null check over the variables this node wrote, so
+      any null anywhere in the extracted value (top-level, list element, or
+      nested field) fails.
+
+    Variables are identified by identity diff against ``vars_before`` so only the
+    values (re)written by this extraction node are inspected — making this safe
+    inside for-loops that overwrite the same variable each iteration.
+    """
+    gv = memory.variables.generated_variables
+
+    if extraction_action.api_call is not None:
+        for var_name in extraction_action.api_call.output_variable_names:
+            result = gv.get(var_name)
+            if isinstance(result, dict) and (
+                result.get("error") is not None or result.get("status_code") is None
+            ):
+                raise ValueError(
+                    f"api_call extraction {var_name!r} failed "
+                    f"(status_code={result.get('status_code')}, "
+                    f"error={result.get('error')!r}) and allow_none is False"
+                )
+        return
+
+    for key, value in gv.items():
+        if vars_before.get(key) is value:
+            continue  # not (re)written by this extraction node
+        if _extraction_response_contains_null(value):
+            raise ValueError(
+                f"Extraction produced null value(s) in variable {key!r} "
+                f"and allow_none is False: {value!r}"
+            )
+
+
 async def run_extraction_action(
     extraction_action: ExtractionAction, memory: Memory, browser: Browser, task: Task
 ):
     logger.debug(
         f"---------Running extraction action {extraction_action.model_dump_json()}---------"
     )
+
+    vars_before = dict(memory.variables.generated_variables)
 
     if extraction_action.llm:
         await handle_llm_extraction(
@@ -116,6 +162,9 @@ async def run_extraction_action(
             memory,
             extraction_action.unique_identifier,
         )
+
+    if not extraction_action.allow_none:
+        _enforce_extraction_not_null(extraction_action, memory, vars_before)
 
 
 async def handle_state_extraction(
@@ -323,6 +372,10 @@ async def handle_llm_extraction(
                 or isinstance(v, bool)
             ):
                 memory.variables.generated_variables[output_variable_name] = [v]
+            elif v is None:
+                # Null is allowed through here; the allow_none policy in
+                # run_extraction_action decides whether it fails the run.
+                memory.variables.generated_variables[output_variable_name] = [None]
             else:
                 raise ValueError(
                     f"Output variable {output_variable_name} must be a string, int, float, bool, or a list of strings, ints, floats, or bools. Extracted values: {response_dict[output_variable_name]}"
@@ -451,6 +504,10 @@ async def handle_python_script_extraction(
                     memory.variables.generated_variables[output_variable_name] = v
                 elif isinstance(v, (str, int, float, bool)):
                     memory.variables.generated_variables[output_variable_name] = [v]
+                elif v is None:
+                    # Null is allowed through here; the allow_none policy in
+                    # run_extraction_action decides whether it fails the run.
+                    memory.variables.generated_variables[output_variable_name] = [None]
                 else:
                     raise ValueError(
                         f"Output variable {output_variable_name} must be a string, int, float, bool, or a list of strings, ints, floats, or bools. Extracted values: {result[output_variable_name]}"

--- a/optexity/schema/actions/extraction_action.py
+++ b/optexity/schema/actions/extraction_action.py
@@ -233,6 +233,7 @@ class APICallExtraction(BaseModel):
 
 class ExtractionAction(BaseModel):
     unique_identifier: str | None = None
+    allow_none: bool = False
     network_call: Optional[NetworkCallExtraction] = None
     llm: Optional[LLMExtraction] = None
     python_script: Optional[PythonScriptExtraction] = None

--- a/optexity/schema/automation.py
+++ b/optexity/schema/automation.py
@@ -189,6 +189,14 @@ class ActionNode(BaseModel):
             for index, value in enumerate(values):
                 pattern = f"{{{key}[{index}]}}"
 
+                if value is None:
+                    # A None value (e.g. a failed locator extraction) cannot be
+                    # substituted into a string. Skip it instead of crashing the
+                    # whole flow on an unrelated variable. The raw None is kept in
+                    # generated_variables, so if/else conditions still evaluate it
+                    # natively (falsy) via evaluate_condition().
+                    continue
+
                 str_value = str(value)
 
                 if isinstance(value, SecureParameter):
@@ -397,82 +405,28 @@ class IfElseNode(BaseModel):
 
 
 class AssertLocatorNode(BaseModel):
-    """Branch on a Playwright locator assertion.
+    """Evaluate a Playwright locator assertion and store the boolean result.
 
     The locator is evaluated against `page` via Browser.get_locator_from_command
     (same `eval("page." + command)` style used by interaction actions). If the
-    assertion holds within `timeout` seconds, `if_nodes` run; otherwise
-    `else_nodes` run. Both branches may be empty (no-op).
+    assertion holds within `timeout` seconds the result is True, otherwise False.
+    The boolean is stored in generated_variables under `output_variable_name`
+    (as a single-element list, e.g. {output_variable_name: [True]}) so it can be
+    referenced later via `{output_variable_name[0]}`, e.g. in an if_else_node
+    condition.
     """
 
     type: Literal["assert_locator_node"]
     locator: str
     assertion: Literal["to_be_visible", "to_be_hidden"]
+    output_variable_name: str
     timeout: float = 5.0
-    if_nodes: list[
-        ActionNode | IfElseNodeRef | ForLoopNodeRef | AssertLocatorNodeRef
-    ] = []
-    else_nodes: list[
-        ActionNode | IfElseNodeRef | ForLoopNodeRef | AssertLocatorNodeRef
-    ] = []
 
     def replace(self, pattern: str, replacement: str | int | float | bool | None):
         replacement_str = "" if replacement is None else str(replacement)
         if self.locator:
             self.locator = self.locator.replace(pattern, replacement_str)
-        for node in self.if_nodes:
-            if hasattr(node, "replace"):
-                node.replace(pattern, replacement_str)
-        for node in self.else_nodes:
-            if hasattr(node, "replace"):
-                node.replace(pattern, replacement_str)
         return self
-
-    @model_validator(mode="before")
-    def migrate_old_nodes(cls, data: dict[str, Any]):
-        for key in ["if_nodes", "else_nodes"]:
-            raw_nodes = data.get(key, [])
-            new_nodes = []
-            used_old_format = False
-
-            for item in raw_nodes:
-                if (
-                    isinstance(item, ActionNode)
-                    or isinstance(item, ForLoopNode)
-                    or isinstance(item, IfElseNode)
-                    or isinstance(item, AssertLocatorNode)
-                ):
-                    new_nodes.append(item)
-                    continue
-
-                if isinstance(item, dict) and "type" in item:
-                    new_nodes.append(item)
-                    continue
-
-                used_old_format = True
-
-                if isinstance(item, dict) and "condition" in item:
-                    new_nodes.append({"type": "if_else_node", **item})
-                    continue
-
-                if isinstance(item, dict) and "variable_name" in item:
-                    new_nodes.append({"type": "for_loop_node", **item})
-                    continue
-
-                if isinstance(item, dict) and "locator" in item and "assertion" in item:
-                    new_nodes.append({"type": "assert_locator_node", **item})
-                    continue
-
-                new_nodes.append({"type": "action_node", **item})
-
-            if used_old_format:
-                logger.warning(
-                    "Old node format without 'type' is deprecated. "
-                    "Use the new format: {'type': 'action_node'|'for_loop_node'|'if_else_node'|'assert_locator_node', ...}"
-                )
-
-            data[key] = new_nodes
-        return data
 
 
 class Parameters(BaseModel):


### PR DESCRIPTION
…itution

Two related changes to variable handling.

1. AssertLocatorNode: emit a boolean instead of branching inline.
   - Replace `if_nodes`/`else_nodes` with a required `output_variable_name`.
   - The handler now stores `[assertion_passed]` in generated_variables under that name instead of running an inline branch. Callers branch on the result with a separate if_else_node (`{var[0]}`), keeping the check reusable and the node single-purpose.
   - Removed the now-dead migrate_old_nodes shim on this node.

2. ActionNode.replace_variables: stop crashing on None values.
   - Previously a None variable (e.g. from a failed locator extraction) hit the `else: raise ValueError("Invalid value type ...")` branch and aborted the whole automation, even when no node referenced that variable.
   - Now None is skipped during string substitution. The raw None stays in generated_variables so if/else conditions still evaluate it natively (falsy) via evaluate_condition(). We intentionally do not substitute "", since "" is a legitimate value that must remain distinguishable.

Docs updated to match: assertion-action.mdx rewritten to the output_variable_name pattern (assert_locator_node + if_else_node), and the docs-manifest entry refreshed.

BREAKING CHANGE: assert_locator_node now requires `output_variable_name` and no longer supports inline `if_nodes`/`else_nodes`. Stored automations using the old shape fail validation on load (loud, not silent) and must be migrated to the two-node pattern.