### PR TITLE
schema: bring RDP url-mode and related schema changes into main

### DIFF
--- a/optexity/schema/actions/interaction_action.py
+++ b/optexity/schema/actions/interaction_action.py
@@ -356,7 +356,7 @@ class KeyPressAction(BaseAction):
 class AgenticTask(BaseModel):
     task: str
     max_steps: int
-    backend: Literal["browser_use", "browserbase"]
+    backend: Literal["browser_use", "browserbase"] = "browser_use"
     use_vision: bool = False
     keep_alive: bool = True
 

--- a/optexity/schema/actions/powershell_action.py
+++ b/optexity/schema/actions/powershell_action.py
@@ -9,6 +9,7 @@ class PowerShellAction(BaseModel):
     """
 
     commands: list[str]
+    exit_after_commands: bool = True
 
     @model_validator(mode="after")
     def validate_commands(self):

--- a/optexity/schema/automation.py
+++ b/optexity/schema/automation.py
@@ -534,14 +534,17 @@ class Automation(BaseModel):
         if self.browser_channel == "rdp":
             for node in self.nodes:
                 if isinstance(node, ActionNode):
-                    if node.interaction_action:
+                    ia = node.interaction_action
+                    if ia:
                         if (
-                            node.interaction_action.click_element is None
-                            and node.interaction_action.input_text is None
-                            and node.interaction_action.key_press is None
+                            ia.click_element is None
+                            and ia.input_text is None
+                            and ia.key_press is None
+                            and ia.agentic_task is None
                         ):
                             raise ValueError(
-                                "Only click_element, input_text, and key_press are allowed for rdp"
+                                "Only click_element, input_text, key_press, and "
+                                "agentic_task are allowed for rdp"
                             )
         return self
 

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -179,6 +179,21 @@ class Task(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_rdp_channel(self):
+        # browser_channel="rdp" runs in one of two modes:
+        #   * rdp_parameter set  -> RDP (xfreerdp) into a remote machine.
+        #   * rdp_parameter None -> open automation.url in a normal browser and
+        #     drive it via pyautogui (computer-use).
+        # The second mode needs a start URL to navigate to.
+        if self.automation.browser_channel == "rdp":
+            if self.rdp_parameter is None and not self.automation.url:
+                raise ValueError(
+                    "browser_channel='rdp' requires either an rdp_parameter "
+                    "(to RDP into a machine) or automation.url (to open in a browser)"
+                )
+        return self
+
+    @model_validator(mode="after")
     def set_dependent_paths(self):
 
         self.logs_directory.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Cherry-picks only the optexity/schema/ changes from ui_agents_prince:
- AgenticTask.backend defaults to "browser_use"
- PowerShellAction.exit_after_commands flag
- allow agentic_task for rdp browser_channel
- Task: validate rdp browser_channel requires rdp_parameter or automation.url