### PR TITLE
feat: optional output_variable_name for locator extraction & assert l…

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -173,11 +173,12 @@ Group related questions with `<AccordionGroup>`:
 <AccordionGroup>
   <Accordion title="How do I handle passwords securely?">
     Use `secure_parameters` with 1Password or TOTP integration.
-    
+
     | Provider | Use Case |
     |----------|----------|
     | 1Password | Passwords, API keys |
     | TOTP | 2FA codes |
+
   </Accordion>
 </AccordionGroup>
 ```

--- a/docs/docs/faqs/AGENTS.md
+++ b/docs/docs/faqs/AGENTS.md
@@ -7,7 +7,7 @@ Use `<AccordionGroup>` to organize FAQs that would otherwise clutter the page.
   <Accordion title="Advanced configuration options">
     Content about advanced settings...
   </Accordion>
-  
+
   <Accordion title="Troubleshooting common issues">
     Solutions to frequent problems...
   </Accordion>

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -615,10 +615,15 @@ async def handle_assert_locator_node(
     full_automation: list,
 ):
     memory.update_system_info()
+    memory.automation_state.step_index += 1
     full_automation.append(assert_node.model_dump())
+    var_name = (
+        assert_node.output_variable_name
+        or f"node{memory.automation_state.step_index}_output"
+    )
     logger.debug(
         f"Handling assert locator node {assert_node.locator} ({assert_node.assertion}) "
-        f"-> {assert_node.output_variable_name}"
+        f"-> {var_name}"
     )
 
     locator = await browser.get_locator_from_command(assert_node.locator)
@@ -648,13 +653,8 @@ async def handle_assert_locator_node(
                 f"failed: {type(e).__name__}"
             )
 
-    memory.variables.generated_variables[assert_node.output_variable_name] = [
-        assertion_passed
-    ]
-    logger.debug(
-        f"Assert locator result={assertion_passed}; stored in "
-        f"{assert_node.output_variable_name!r}"
-    )
+    memory.variables.generated_variables[var_name] = [assertion_passed]
+    logger.debug(f"Assert locator result={assertion_passed}; stored in {var_name!r}")
     memory.update_system_info()
 
 

--- a/optexity/inference/core/run_extraction.py
+++ b/optexity/inference/core/run_extraction.py
@@ -379,7 +379,19 @@ async def handle_locator_extraction(
     task: Task,
     unique_identifier: str | None = None,
 ):
-    var_name = locator_extraction.output_variable_name
+    # Resolve the storage key: explicit name, else the node's index.
+    var_name = (
+        locator_extraction.output_variable_name
+        or f"node{memory.automation_state.step_index}_output"
+    )
+    # The LLM fallback reads this field out of the extraction_format. When the
+    # name is explicit it is itself a format key; otherwise the validator
+    # guarantees the format has exactly one field, whose value we remap.
+    format_key = (
+        locator_extraction.output_variable_name
+        if locator_extraction.output_variable_name is not None
+        else next(iter(locator_extraction.extraction_format))
+    )
     extracted_value = None
     locator_failed = False
 
@@ -408,15 +420,26 @@ async def handle_locator_extraction(
                 llm_extraction = LLMExtraction(
                     extraction_format=locator_extraction.extraction_format,
                     extraction_instructions=locator_extraction.extraction_instructions,
-                    output_variable_names=[var_name],
+                    output_variable_names=[format_key],
                     llm_provider=locator_extraction.llm_provider,
                     llm_model_name=locator_extraction.llm_model_name,
                 )
                 output = await handle_llm_extraction(
                     llm_extraction, memory, browser, task, unique_identifier
                 )
-                if output is not None and var_name in output.json_data:
-                    extracted_value = output.json_data[var_name]
+                if output is not None and format_key in output.json_data:
+                    extracted_value = output.json_data[format_key]
+                # handle_llm_extraction stored the value under format_key; move
+                # it to the resolved name when they differ (synthesized name).
+                if format_key != var_name:
+                    if format_key in memory.variables.generated_variables:
+                        memory.variables.generated_variables[var_name] = (
+                            memory.variables.generated_variables.pop(format_key)
+                        )
+                    else:
+                        memory.variables.generated_variables[var_name] = [
+                            extracted_value
+                        ]
                 logger.debug(f"LLM fallback extracted {var_name}={extracted_value!r}")
             except Exception as e:
                 logger.warning(f"LLM fallback also failed for {var_name!r}: {e}")

--- a/optexity/schema/actions/extraction_action.py
+++ b/optexity/schema/actions/extraction_action.py
@@ -183,7 +183,9 @@ class VisionExtraction(BaseModel):
 
 class LocatorExtraction(BaseModel):
     command: str
-    output_variable_name: str
+    # Optional: when omitted, the result is stored under ``node{index}_output``
+    # (the node's step index), resolved at runtime.
+    output_variable_name: str | None = None
     extraction_format: dict
     extraction_instructions: str | None = None
     llm_provider: Literal["gemini"] = "gemini"
@@ -191,6 +193,16 @@ class LocatorExtraction(BaseModel):
 
     @model_validator(mode="after")
     def validate_variable_in_format(self):
+        if self.output_variable_name is None:
+            # No explicit name: the synthesized ``node{index}_output`` key is
+            # not in the (statically authored) format, so the format must
+            # describe exactly one field, which we remap at runtime.
+            if len(self.extraction_format) != 1:
+                raise ValueError(
+                    "When output_variable_name is omitted, extraction_format "
+                    "must contain exactly one field"
+                )
+            return self
         if self.output_variable_name not in self.extraction_format:
             raise ValueError(
                 f"Variable {self.output_variable_name!r} not found in extraction_format"

--- a/optexity/schema/automation.py
+++ b/optexity/schema/automation.py
@@ -413,13 +413,14 @@ class AssertLocatorNode(BaseModel):
     The boolean is stored in generated_variables under `output_variable_name`
     (as a single-element list, e.g. {output_variable_name: [True]}) so it can be
     referenced later via `{output_variable_name[0]}`, e.g. in an if_else_node
-    condition.
+    condition. When `output_variable_name` is omitted, the result is stored under
+    `node{index}_output`, where index is the node's step index resolved at runtime.
     """
 
     type: Literal["assert_locator_node"]
     locator: str
     assertion: Literal["to_be_visible", "to_be_hidden"]
-    output_variable_name: str
+    output_variable_name: str | None = None
     timeout: float = 5.0
 
     def replace(self, pattern: str, replacement: str | int | float | bool | None):


### PR DESCRIPTION
…ocator

Make output_variable_name optional on LocatorExtraction and AssertLocatorNode. When omitted, the result is stored under node{index}_output, where index is the node's step index resolved at runtime.

- LocatorExtraction: when name omitted, extraction_format must have exactly one field; the LLM fallback extracts that field but stores it under the synthesized name (remap on the generated_variables key).
- AssertLocatorNode: handler now bumps step_index so each assert node owns a unique index, preventing collisions between consecutive unnamed assert nodes.