### PR TITLE
feat: per-run integration_secret selection (multi-credential)

### DIFF
--- a/docs/api-reference/inference-endpoint.mdx
+++ b/docs/api-reference/inference-endpoint.mdx
@@ -62,6 +62,10 @@ The inference endpoint is the primary way to submit automation tasks to an Optex
 
     Every name in this list must exist as a key in `input_parameters`.
 
+- **`integration_secret_id`** `string` _optional_
+
+    Id of the stored credential (AWS Secrets Manager or 1Password) to use when resolving this task's `secure_parameters`. Lets the same automation run against different credentials. When omitted, the workspace's active credential of the matching type is used. See [AWS Secrets Manager](/docs/advanced/aws-secrets-manager#using-multiple-credentials) and [1Password](/docs/advanced/onepassword#using-multiple-credentials).
+
 ## Code Examples
 
 <CodeGroup>

--- a/docs/docs/advanced/aws-secrets-manager.mdx
+++ b/docs/docs/advanced/aws-secrets-manager.mdx
@@ -44,6 +44,12 @@ AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 ```
 
+<Tip>
+You can store **more than one** set of AWS credentials. On the **Integrations** page, give
+each credential a **name** (e.g. `prod-account`, `client-acme`) and add as many as you need.
+See [Using multiple credentials](#using-multiple-credentials) below to choose which one a run uses.
+</Tip>
+
 ---
 
 ## Usage
@@ -103,6 +109,34 @@ If your secret is stored as a JSON object like `{"username": "admin", "password"
 | `key` | `str` | `null` | Key to extract from the secret (plain string or JSON object) |
 | `type` | `str` | `null` | Set to `"totp_secret"` to generate TOTP codes |
 | `digits` | `int` | `null` | Required when `type` is `"totp_secret"` (e.g. `6`) |
+
+---
+
+## Using multiple credentials
+
+A single workflow can run against **different AWS credentials** without being duplicated —
+useful when the same automation serves multiple AWS accounts, clients, or environments.
+
+Store each credential set on the **Integrations** page with a distinct **name**, then pick
+which one a run should use:
+
+- **Dashboard** — choose the credential from the picker in the run dialog before starting a run.
+- **API** — pass `integration_secret_id` (the id of the stored credential) when triggering a run:
+
+```json
+{
+  "input_params": { "...": "..." },
+  "integration_secret_id": "b1f2c3d4-5678-90ab-cdef-1234567890ab"
+}
+```
+
+The selected credential is used to resolve every `amazon_secrets_manager` secure parameter in
+that run.
+
+<Note>
+If `integration_secret_id` is omitted, the run falls back to the workspace's active
+AWS Secrets Manager credential — so existing workflows keep working unchanged.
+</Note>
 
 ---
 

--- a/docs/docs/advanced/onepassword.mdx
+++ b/docs/docs/advanced/onepassword.mdx
@@ -38,6 +38,12 @@ Add it directly on the **Integrations** page of the dashboard, or if you are run
 OP_SERVICE_ACCOUNT_TOKEN=your_service_account_token
 ```
 
+<Tip>
+You can store **more than one** 1Password service account. On the **Integrations** page,
+give each credential a **name** (e.g. `prod`, `client-acme`) and add as many as you need.
+See [Using multiple credentials](#using-multiple-credentials) below to choose which one a run uses.
+</Tip>
+
 ---
 
 ## Usage
@@ -79,6 +85,33 @@ Move parameters from `input_parameters` to `secure_parameters`:
 | `field_name` | Field to retrieve |
 | `type` | Set to `"totp_secret"` to generate TOTP codes |
 | `digits` | Required when `type` is `"totp_secret"` (e.g., `6`) |
+
+---
+
+## Using multiple credentials
+
+A single workflow can run against **different 1Password service accounts** without being
+duplicated — useful when the same automation serves multiple teams, clients, or environments.
+
+Store each service account on the **Integrations** page with a distinct **name**, then pick
+which one a run should use:
+
+- **Dashboard** — choose the credential from the picker in the run dialog before starting a run.
+- **API** — pass `integration_secret_id` (the id of the stored credential) when triggering a run:
+
+```json
+{
+  "input_params": { "...": "..." },
+  "integration_secret_id": "b1f2c3d4-5678-90ab-cdef-1234567890ab"
+}
+```
+
+The selected credential is used to resolve every `onepassword` secure parameter in that run.
+
+<Note>
+If `integration_secret_id` is omitted, the run falls back to the workspace's active
+1Password credential — so existing workflows keep working unchanged.
+</Note>
 
 ---
 

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -347,7 +347,10 @@ async def run_action_node(
 
     await action_node.replace_variables(task.input_parameters)
     await action_node.replace_variables(
-        task.secure_parameters, task.workspace_id, task.api_key
+        task.secure_parameters,
+        task.workspace_id,
+        task.api_key,
+        task.integration_secret_id,
     )
     await action_node.replace_variables(memory.variables.generated_variables)
     resolve_api_variables_in_node(action_node, memory.variables.generated_variables)

--- a/optexity/schema/automation.py
+++ b/optexity/schema/automation.py
@@ -181,6 +181,7 @@ class ActionNode(BaseModel):
         variables: dict[str, list[str | SecureParameter]],
         workspace_id: str | None = None,
         api_key: str | None = None,
+        integration_secret_id: str | None = None,
     ):
         for key, values in variables.items():
             if not isinstance(values, list):
@@ -207,6 +208,7 @@ class ActionNode(BaseModel):
                             value.onepassword.field_name,
                             workspace_id,
                             api_key,
+                            integration_secret_id,
                         )
                         if value.onepassword.type == "totp_secret":
                             str_value = get_totp_code(
@@ -221,6 +223,7 @@ class ActionNode(BaseModel):
                             asm.key,
                             workspace_id,
                             api_key,
+                            integration_secret_id,
                         )
                         if asm.type == "totp_secret":
                             assert asm.digits is not None

--- a/optexity/schema/inference.py
+++ b/optexity/schema/inference.py
@@ -26,6 +26,9 @@ class InferenceRequest(BaseModel):
     per_login_parallelism: int = 1
     task_callback_url: str | None = None
     task_callback_api_key: str | None = None
+    # Optional: id of the integration_secret (stored credential) to use for this
+    # run. When None, the workspace's active credential of the matching type is used.
+    integration_secret_id: str | None = None
 
     @model_validator(mode="after")
     def validate_use_proxy(self):

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -126,6 +126,9 @@ class Task(BaseModel):
     # dedicated_service DB row governs the service.
     max_parallelism: int = 1
     per_login_parallelism: int = 1
+    # Optional: id of the integration_secret (stored credential) to use when
+    # resolving secure parameters for this task. None -> active credential by type.
+    integration_secret_id: str | None = None
     company_id: CompanyID
     llm_provider: Literal["gemini", "anthropic", "openai"] = "gemini"
     llm_model_name: str = "gemini-2.5-flash"

--- a/optexity/utils/aws_secret_manager.py
+++ b/optexity/utils/aws_secret_manager.py
@@ -11,13 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 async def _resolve_aws_credentials(
-    workspace_id: str | None, api_key: str | None = None
+    workspace_id: str | None,
+    api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> tuple[str, str]:
     """Resolve AWS credentials.
 
     Prefers fetching the 'aws_secret_manager' integration secret from the opbackend API
     when workspace_id is provided; falls back to AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
-    env vars.
+    env vars. When integration_secret_id is set, that specific credential is fetched;
+    otherwise the workspace's active credential of this type is used.
     """
     if workspace_id is not None:
         try:
@@ -26,7 +29,10 @@ async def _resolve_aws_credentials(
             )
 
             data = await fetch_decrypted_integration_secret(
-                workspace_id, "aws_secret_manager", api_key
+                workspace_id,
+                "aws_secret_manager",
+                api_key,
+                integration_secret_id,
             )
             access_key = data.get("access_key_id")
             secret_key = data.get("secret_access_key")
@@ -102,11 +108,17 @@ async def get_aws_secret_value(
     key: str | None = None,
     workspace_id: str | None = None,
     api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> str:
     """
     Cached helper to fetch a value from AWS Secrets Manager.
+
+    integration_secret_id is part of the cache key, so selecting a different stored
+    credential resolves independently rather than returning a cached value.
     """
-    access_key, secret_key = await _resolve_aws_credentials(workspace_id, api_key)
+    access_key, secret_key = await _resolve_aws_credentials(
+        workspace_id, api_key, integration_secret_id
+    )
     manager = AWSSecretsManager(region_name, access_key, secret_key)
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(

--- a/optexity/utils/integration_secrets.py
+++ b/optexity/utils/integration_secrets.py
@@ -11,12 +11,19 @@ logger = logging.getLogger(__name__)
 
 
 async def fetch_decrypted_integration_secret(
-    workspace_id: str, secret_type: str, api_key: str | None = None
+    workspace_id: str,
+    secret_type: str,
+    api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> dict:
     """Fetch an integration secret from the opbackend API and decrypt it.
 
     Makes a GET request to /integration-secrets/{type}/encrypt using the configured
     API key, then decrypts the Fernet-encrypted payload with FERNET_SECRET_KEY.
+
+    When integration_secret_id is provided it is sent as the `secret_id` query param
+    so the server returns that specific credential; otherwise the server returns the
+    workspace's active credential of the given type.
     """
     url = urljoin(
         settings.SERVER_URL,
@@ -26,10 +33,11 @@ async def fetch_decrypted_integration_secret(
         "x-api-key": api_key if api_key is not None else settings.OPTEXITY_API_KEY,
         "x-workspace-id": workspace_id,
     }
+    params = {"secret_id": integration_secret_id} if integration_secret_id else None
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url, headers=headers)
+            response = await client.get(url, headers=headers, params=params)
             response.raise_for_status()
 
         body = response.json()

--- a/optexity/utils/utils.py
+++ b/optexity/utils/utils.py
@@ -30,12 +30,16 @@ _onepassword_clients: dict[str, OnePasswordClient] = {}
 
 
 async def _get_onepassword_token(
-    workspace_id: str | None, api_key: str | None = None
+    workspace_id: str | None,
+    api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> str:
     """Resolve the 1Password service-account token.
 
     Prefers fetching the 'one_password' integration secret from the opbackend API
     when workspace_id is provided; falls back to the OP_SERVICE_ACCOUNT_TOKEN env var.
+    When integration_secret_id is set, that specific credential is fetched; otherwise
+    the workspace's active credential of this type is used.
     """
     if workspace_id is not None:
         try:
@@ -44,7 +48,10 @@ async def _get_onepassword_token(
             )
 
             data = await fetch_decrypted_integration_secret(
-                workspace_id, "one_password", api_key
+                workspace_id,
+                "one_password",
+                api_key,
+                integration_secret_id,
             )
             token = data.get("service_account_token")
             if token:
@@ -70,9 +77,11 @@ async def _get_onepassword_token(
 
 
 async def get_onepassword_client(
-    workspace_id: str | None = None, api_key: str | None = None
+    workspace_id: str | None = None,
+    api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> OnePasswordClient:
-    token = await _get_onepassword_token(workspace_id, api_key)
+    token = await _get_onepassword_token(workspace_id, api_key, integration_secret_id)
     if token not in _onepassword_clients:
         _onepassword_clients[token] = await OnePasswordClient.authenticate(
             auth=token,
@@ -133,8 +142,9 @@ async def get_onepassword_value(
     field_name: str,
     workspace_id: str | None = None,
     api_key: str | None = None,
+    integration_secret_id: str | None = None,
 ) -> str:
-    client = await get_onepassword_client(workspace_id, api_key)
+    client = await get_onepassword_client(workspace_id, api_key, integration_secret_id)
     return await client.secrets.resolve(f"op://{vault_name}/{item_name}/{field_name}")
 
 


### PR DESCRIPTION
## Summary

Threads an optional `integration_secret_id` through the automation execution path so a run can resolve `amazon_secrets_manager` / `onepassword` secure-parameters using a **specific** stored credential instead of always the workspace's active one. Enables per-run multi-credential selection.

This is the **package** half of the feature and is **purely additive** — every new field/param defaults to `None`, so deploying it alone changes nothing. **Deploy this before the `optexity-internal` PR**, which consumes these fields and the `?secret_id=` query param.

## Changes

- `schema/inference.py` — `InferenceRequest.integration_secret_id`
- `schema/task.py` — `Task.integration_secret_id`
- `inference/core/run_automation.py` — `run_action_node` forwards `task.integration_secret_id` to `replace_variables`
- `schema/automation.py` — `replace_variables` forwards to both `get_aws_secret_value` and `get_onepassword_value`
- `utils/aws_secret_manager.py` — `get_aws_secret_value` (id in the `@alru_cache` key) + `_resolve_aws_credentials`
- `utils/utils.py` — `get_onepassword_value` / `_get_onepassword_token`
- `utils/integration_secrets.py` — `fetch_decrypted_integration_secret` sends `secret_id` query param when set
- **docs**: `advanced/aws-secrets-manager.mdx` + `advanced/onepassword.mdx` (new "Using multiple credentials" sections), `api-reference/inference-endpoint.mdx` (`integration_secret_id` body param)

## Compatibility

Additive only; all callers updated. **Not a breaking change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
