### PR TITLE
fix(upload): defer file_url scheme check to run time

### DIFF
--- a/optexity/inference/core/interaction/handle_upload.py
+++ b/optexity/inference/core/interaction/handle_upload.py
@@ -88,6 +88,10 @@ async def handle_upload_file(
 ):
     tmp_path: str | None = None
     if upload_file_action.file_url:
+        if not upload_file_action.file_url.startswith(("http://", "https://")):
+            raise ValueError(
+                "UploadFileAction.file_url must be an http:// or https:// URL"
+            )
         tmp_path = await _download_to_temp_file(upload_file_action.file_url, browser)
         upload_file_action.file_path = tmp_path
 

--- a/optexity/schema/actions/interaction_action.py
+++ b/optexity/schema/actions/interaction_action.py
@@ -241,10 +241,9 @@ class UploadFileAction(BaseAction):
             raise ValueError(
                 "UploadFileAction: exactly one of file_path or file_url must be set"
             )
-        if self.file_url and not self.file_url.startswith(("http://", "https://")):
-            raise ValueError(
-                "UploadFileAction.file_url must be an http:// or https:// URL"
-            )
+        # The http(s) scheme of file_url is validated at run time in
+        # handle_upload_file, after templated placeholders (e.g.
+        # "{upload_file_url[0]}") have been substituted with the real URL.
         return self
 
     def replace(self, pattern: str, replacement: str):


### PR DESCRIPTION
Move the http(s) URL-scheme validation for UploadFileAction.file_url out of the Pydantic model validator (which runs at recording save/update time) and into handle_upload_file at run time, after templated placeholders like "{upload_file_url[0]}" have been substituted.

Recordings can now be saved with a templated file_url; the resolved URL is still validated before download. The structural "exactly one of file_path/file_url" check is kept at save time.