### PR TITLE
feat(queue): optional priority on tasks + child priority queue

### DIFF
--- a/docs/api-reference/inference-endpoint.mdx
+++ b/docs/api-reference/inference-endpoint.mdx
@@ -19,7 +19,7 @@ The inference endpoint is the primary way to submit automation tasks to an Optex
 </Info>
 
 <Info>
-    Cloud endpoint (`https://inference-api.optexity.com/api/v1/inference`) requires authentication with an API
+    Cloud endpoint (`https://api.optexity.com/api/v1/inference`) requires authentication with an API
     key in the request header. API keys can be found in the Optexity dashboard under the "API Keys"
     section. This requires a paid plan. Contact us at founders@optexity.com to get a paid plan.
 </Info>
@@ -62,11 +62,24 @@ The inference endpoint is the primary way to submit automation tasks to an Optex
 
     Every name in this list must exist as a key in `input_parameters`.
 
+- **`priority`** `integer` _optional_
+
+    Queue priority for this task within its login‑queue. **Lower number runs first; negatives allowed; omit (or send `null`) to run last.**
+
+    | Value | Behaviour |
+    | --- | --- |
+    | Negative (e.g. `−5`, `−1`) | Runs before all positive and null tasks |
+    | `0` | Runs after negatives, before positives |
+    | Positive (e.g. `1`, `3`) | Runs before null tasks |
+    | `null` / omitted | Runs last (default — preserves FIFO ordering) |
+
+    Priority only reorders *waiting* tasks — a currently‑running task is never interrupted. Scope is per login‑queue and never affects other users or other portals.
+
 ## Code Examples
 
 <CodeGroup>
 
-```bash cURL
+```bash cURL (local)
 curl -X POST http://localhost:9000/inference \
   -H "Content-Type: application/json" \
   -d '{
@@ -77,6 +90,21 @@ curl -X POST http://localhost:9000/inference \
       "date_range": ["last-30-days"]
     },
     "unique_parameter_names": ["username", "date_range"]
+  }'
+```
+
+```bash cURL (cloud)
+curl -X POST https://api.optexity.com/api/v1/inference \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $OPTEXITY_API_KEY" \
+  -d '{
+    "endpoint_name": "order-scraper",
+    "input_parameters": {
+      "username": ["admin@company.com"],
+      "date_range": ["last-30-days"]
+    },
+    "unique_parameter_names": ["username"],
+    "priority": -1
   }'
 ```
 
@@ -168,6 +196,7 @@ curl -X POST http://localhost:9000/inference \
 
 The task has been enqueued and will execute asynchronously.
 
+**Local endpoint** (`http://localhost:9000/inference`):
 ```json
 {
     "success": true,
@@ -175,12 +204,22 @@ The task has been enqueued and will execute asynchronously.
 }
 ```
 
+**Cloud endpoint** (`https://api.optexity.com/api/v1/inference`):
+```json
+{
+    "success": true,
+    "message": "Task has been allocated. Check its status and output at https://dashboard.optexity.com/tasks",
+    "task_id": "bf982ff9-f0af-4598-97be-2eb99c917eb0"
+}
+```
+
 **Response Fields:**
 
-| Field     | Type    | Description                                  |
-| --------- | ------- | -------------------------------------------- |
-| `success` | boolean | Indicates whether the request was successful |
-| `message` | string  | Status message describing the result         |
+| Field      | Type    | Description                                                        |
+| ---------- | ------- | ------------------------------------------------------------------ |
+| `success`  | boolean | Indicates whether the request was successful                       |
+| `message`  | string  | Status message describing the result                               |
+| `task_id`  | string  | UUID of the queued task *(cloud endpoint only)*. Use this to poll status or request a live stream. |
 
 ## Error Responses
 
@@ -254,7 +293,7 @@ Returned when an unexpected server error occurs.
 ## How It Works
 
 1. The inference server receives the `InferenceRequest`
-2. It forwards the request to the Optexity control plane at `inference-api.optexity.com`
+2. It forwards the request to the Optexity control plane at `api.optexity.com`
 3. The control plane returns a serialized `Task` object containing the full workflow
 4. The task is enqueued locally for background execution
 5. A `202 Accepted` response is returned immediately
@@ -309,6 +348,9 @@ class Task:
     logs_directory: Path | None
     downloads_directory: Path | None
     log_file_path: Path | None
+
+    # Queue priority (lower = higher urgency; None = last)
+    priority: int | None
 
     # Deduplication
     dedup_key: str

--- a/docs/api-reference/stream-endpoint.mdx
+++ b/docs/api-reference/stream-endpoint.mdx
@@ -39,7 +39,7 @@ Requires an API key in the `x-api-key` header. The same key used for `POST /api/
 
 ```bash cURL
 curl -X GET \
-  "https://inference-api.optexity.com/api/v1/tasks/<task_id>/stream" \
+  "https://api.optexity.com/api/v1/tasks/<task_id>/stream" \
   -H "x-api-key: $OPTEXITY_API_KEY"
 ```
 
@@ -49,7 +49,7 @@ import requests
 
 task_id = "bf982ff9-f0af-4598-97be-2eb99c917eb0"
 resp = requests.get(
-    f"https://inference-api.optexity.com/api/v1/tasks/{task_id}/stream",
+    f"https://api.optexity.com/api/v1/tasks/{task_id}/stream",
     headers={"x-api-key": os.environ["OPTEXITY_API_KEY"]},
 )
 resp.raise_for_status()
@@ -60,7 +60,7 @@ print(stream_url)
 ```javascript JavaScript
 const taskId = "bf982ff9-f0af-4598-97be-2eb99c917eb0";
 const res = await fetch(
-    `https://inference-api.optexity.com/api/v1/tasks/${taskId}/stream`,
+    `https://api.optexity.com/api/v1/tasks/${taskId}/stream`,
     { headers: { "x-api-key": process.env.OPTEXITY_API_KEY } },
 );
 if (!res.ok) {
@@ -129,7 +129,7 @@ Install with `npm install @novnc/novnc`.
 import { useEffect, useRef, useState } from "react";
 import RFB from "@novnc/novnc";
 
-const INFERENCE_API_BASE_URL = "https://inference-api.optexity.com";
+const INFERENCE_API_BASE_URL = "https://api.optexity.com";
 
 async function getStreamUrl(taskId, apiKey) {
     const res = await fetch(
@@ -239,7 +239,7 @@ export function LiveStreamViewer({ taskId, apiKey }) {
     <script type="module">
         import RFB from "https://cdn.jsdelivr.net/npm/@novnc/novnc@1.5.0/lib/rfb.js";
 
-        const INFERENCE_API_BASE_URL = "https://inference-api.optexity.com";
+        const INFERENCE_API_BASE_URL = "https://api.optexity.com";
         const TASK_ID = "<your_task_id>";
         const API_KEY = "<your_api_key>";
 
@@ -308,7 +308,7 @@ export function LiveStreamViewer({ taskId, apiKey }) {
 import { ref, onMounted, onBeforeUnmount } from "vue";
 import RFB from "@novnc/novnc";
 
-const INFERENCE_API_BASE_URL = "https://inference-api.optexity.com";
+const INFERENCE_API_BASE_URL = "https://api.optexity.com";
 
 const props = defineProps({
     taskId: { type: String, required: true },
@@ -403,7 +403,7 @@ import {
 // @ts-ignore — @novnc/novnc ships ESM without bundled types
 import RFB from "@novnc/novnc";
 
-const INFERENCE_API_BASE_URL = "https://inference-api.optexity.com";
+const INFERENCE_API_BASE_URL = "https://api.optexity.com";
 
 type StreamState = "loading" | "connecting" | "connected" | "disconnected" | "error";
 

--- a/docs/docs/getting_started/running-first-inference.mdx
+++ b/docs/docs/getting_started/running-first-inference.mdx
@@ -66,7 +66,7 @@ curl -X POST http://localhost:9000/inference \
 
 On success, the inference server:
 
-1. Forwards the request to your control plane at `inference-api.optexity.com` using `INFERENCE_ENDPOINT` (defaults to `api/v1/inference`).
+1. Forwards the request to your control plane at `api.optexity.com` using `INFERENCE_ENDPOINT` (defaults to `api/v1/inference`).
 2. Receives a serialized `Task` object from the control plane.
 3. Enqueues that `Task` locally and starts processing it in the background.
 4. Returns a `202 Accepted` response like:

--- a/docs/docs/inference/dedicated-instances.mdx
+++ b/docs/docs/inference/dedicated-instances.mdx
@@ -27,7 +27,7 @@ For the common case, the defaults are exactly what you want — **just add
 logged‑in container for the portal, with your tasks served one after another on it.
 
 ```bash
-curl -X POST https://inference-api.optexity.com/api/v1/inference \
+curl -X POST https://api.optexity.com/api/v1/inference \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
   -d '{
@@ -44,7 +44,7 @@ curl -X POST https://inference-api.optexity.com/api/v1/inference \
 the request above behaves identically to simply:
 
 ```bash
-curl -X POST https://inference-api.optexity.com/api/v1/inference \
+curl -X POST https://api.optexity.com/api/v1/inference \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
   -d '{
@@ -65,6 +65,7 @@ Set `"is_dedicated": false` (or omit it) for a normal, non‑dedicated run.
 | `max_parallelism` | `int` | `1` | no | Maximum number of warm containers for this portal (service‑wide cap across all logins). |
 | `per_login_parallelism` | `int` | `1` | no | Maximum number of containers a **single login** may use before its extra tasks round‑robin onto those containers. |
 | `unique_parameter_names` | `list[str]` | `[]` | no | Which input parameters identify a "login" / queue. **Each name must be one of the keys in `input_parameters`.** See [Controlling the queue](#controlling-the-queue). |
+| `priority` | `int \| null` | `null` | no | Queue priority. **Lower runs first; negatives allowed; omit to run last.** Only reorders tasks within the same login‑queue. See [Task priority](#task-priority). |
 
 <Tip>
 Defaults work great. Start with just `is_dedicated: true` and only raise the parallelism
@@ -86,7 +87,7 @@ fields once you actually need more concurrency.
   re‑login less often.
 - **Queue‑and‑return.** If there's no free capacity when your request arrives, the request is
   **accepted and queued** (not rejected, not blocked). It runs as soon as capacity frees up.
-  Requests for a given portal are served in **first‑in, first‑out** order.
+  Requests for a given login‑queue are served in **priority order** (lower number runs first; omitted priority runs last). Tasks with the same priority run **first‑in, first‑out**.
 
 ## Examples
 
@@ -210,6 +211,39 @@ If you route **different logins** onto the same queue, the container re‑logs�
 login changes between consecutive tasks — you trade away the "stay logged in" benefit for
 ordering/serialization control. Keep the same login on a queue to keep its session warm.
 </Warning>
+
+## Task priority
+
+By default tasks in a queue run **first‑in, first‑out**. Set `priority` to run an
+urgent task ahead of already‑queued ones without interrupting any currently running task.
+
+```bash
+curl -X POST https://api.optexity.com/api/v1/inference \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
+  -d '{
+    "endpoint_name": "billing_portal",
+    "input_parameters": { "username": ["alice@example.com"] },
+    "unique_parameter_names": ["username"],
+    "is_dedicated": true,
+    "priority": -1
+  }'
+```
+
+| Priority value | Runs |
+| --- | --- |
+| Negative (e.g. `-5`, `-1`) | Before everything else (most urgent) |
+| `0` | After negatives, before positives |
+| Positive (e.g. `1`, `3`) | After zero, before omitted |
+| `null` / omitted | **Last** — default, preserves current FIFO behaviour |
+
+Ties within the same priority value break on arrival order (FIFO).
+
+**Key rules:**
+
+- **No preemption.** A currently‑running task is never interrupted; priority only reorders *waiting* tasks.
+- **Scope is per login‑queue.** A high‑priority task can only jump ahead of tasks in its own login‑queue — it never affects other users or other portals.
+- **Restart preserves priority.** Restarting a task re‑queues it with its original priority.
 
 ## Things to take special care of
 

--- a/docs/docs/inference/dedicated-instances.mdx
+++ b/docs/docs/inference/dedicated-instances.mdx
@@ -27,7 +27,7 @@ For the common case, the defaults are exactly what you want — **just add
 logged‑in container for the portal, with your tasks served one after another on it.
 
 ```bash
-curl -X POST https://api.optexity.com/api/v1/inference \
+curl -X POST https://inference-api.optexity.com/api/v1/inference \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
   -d '{
@@ -44,7 +44,7 @@ curl -X POST https://api.optexity.com/api/v1/inference \
 the request above behaves identically to simply:
 
 ```bash
-curl -X POST https://api.optexity.com/api/v1/inference \
+curl -X POST https://inference-api.optexity.com/api/v1/inference \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
   -d '{
@@ -218,7 +218,7 @@ By default tasks in a queue run **first‑in, first‑out**. Set `priority` to r
 urgent task ahead of already‑queued ones without interrupting any currently running task.
 
 ```bash
-curl -X POST https://api.optexity.com/api/v1/inference \
+curl -X POST https://inference-api.optexity.com/api/v1/inference \
   -H "Content-Type: application/json" \
   -H "x-api-key: YOUR_OPTEXITY_API_KEY" \
   -d '{

--- a/docs/docs/inference/inference-api.mdx
+++ b/docs/docs/inference/inference-api.mdx
@@ -107,7 +107,7 @@ When **`is_aws=False`** (local mode, recommended for development):
 - **`POST /inference`**
     - **Body**: `InferenceRequest` JSON.
     - **Behavior**:
-        1. Sends the request to `api.optexity.com` + `INFERENCE_ENDPOINT` with header `x-api-key: OPTEXITY_API_KEY`.
+        1. Sends the request to `inference-api.optexity.com` + `INFERENCE_ENDPOINT` with header `x-api-key: OPTEXITY_API_KEY`.
         2. Expects a response containing a serialized `Task`.
         3. Enqueues that `Task` onto a local priority queue (ordered by `priority`, then arrival time).
         4. Returns `202 Accepted` with:

--- a/docs/docs/inference/inference-api.mdx
+++ b/docs/docs/inference/inference-api.mdx
@@ -52,6 +52,14 @@ Defined in `optexity/schema/inference.py`:
     - Validation ensures every name in `unique_parameter_names` exists as a key in `input_parameters`.
     - If no `unique_parameter_names` are provided, the task will be allocated immediately.
 
+- **`priority: int | None`** *(optional, default `null`)*
+    - Queue priority for this task within its login‑queue.
+    - **Lower number runs first.** Negatives are allowed (`-10` beats `-1` beats `0` beats `5` beats `null`).
+    - `null` (or omitting the field) runs last — preserves the previous FIFO behaviour.
+    - Ties at the same priority value break on arrival order (FIFO).
+    - Priority is scoped per login‑queue and never affects other users or other portals.
+    - A running task is never preempted; priority only reorders *waiting* tasks.
+
 ### `Task`
 
 Defined in `optexity/schema/task.py`:
@@ -99,9 +107,9 @@ When **`is_aws=False`** (local mode, recommended for development):
 - **`POST /inference`**
     - **Body**: `InferenceRequest` JSON.
     - **Behavior**:
-        1. Sends the request to `inference-api.optexity.com` + `INFERENCE_ENDPOINT` with header `x-api-key: OPTEXITY_API_KEY`.
+        1. Sends the request to `api.optexity.com` + `INFERENCE_ENDPOINT` with header `x-api-key: OPTEXITY_API_KEY`.
         2. Expects a response containing a serialized `Task`.
-        3. Enqueues that `Task` onto a local `asyncio.Queue`.
+        3. Enqueues that `Task` onto a local priority queue (ordered by `priority`, then arrival time).
         4. Returns `202 Accepted` with:
             - `{"success": true, "message": "Task has been allocated"}` on success.
 

--- a/optexity/inference/child_process.py
+++ b/optexity/inference/child_process.py
@@ -50,8 +50,21 @@ child_process_id = -1
 unique_child_arn: str = str(uuid.uuid4())
 task_running = False
 last_task_start_time = None
-task_queue: asyncio.Queue[Task] = asyncio.Queue()
+task_queue: asyncio.PriorityQueue = asyncio.PriorityQueue()
+# Monotonic tie-breaker so equal-priority entries stay FIFO and heap ordering
+# never compares Task objects. See Task.priority_order_key.
+_task_seq = 0
 tasks_to_kill: set[str] = set()
+
+
+def _enqueue_task(task: Task) -> None:
+    """Put a task on the local priority queue: lower priority runs first, None
+    last, ties FIFO. The queue is unbounded so put_nowait never blocks."""
+    global _task_seq
+    _task_seq += 1
+    task_queue.put_nowait((*task.priority_order_key(), _task_seq, task))
+
+
 # task_id -> worker subprocess, so /kill_task can signal an in-flight worker.
 running_task_processes: dict[str, asyncio.subprocess.Process] = {}
 _global_actual_browser: ActualBrowser | None = None
@@ -347,8 +360,9 @@ async def task_processor():
 
     while True:
         try:
-            # Get next task from queue (blocks until one is available)
-            task = await task_queue.get()
+            # Get next task from queue (blocks until one is available);
+            # highest priority (lowest key) first, then FIFO.
+            *_, task = await task_queue.get()
             if task.task_id in tasks_to_kill:
                 logger.info(f"Task {task.task_id} has been killed")
                 tasks_to_kill.remove(task.task_id)
@@ -539,7 +553,7 @@ def get_app_with_endpoints(is_aws: bool, child_id: int, port: int = -1):
         """Get details of a specific task."""
         try:
 
-            await task_queue.put(task)
+            _enqueue_task(task)
             return JSONResponse(
                 content={
                     "success": True,
@@ -579,7 +593,7 @@ def get_app_with_endpoints(is_aws: bool, child_id: int, port: int = -1):
                     )
                 task.is_dedicated = inference_request.is_dedicated
                 task.allocated_at = datetime.now(timezone.utc)
-                await task_queue.put(task)
+                _enqueue_task(task)
 
                 return JSONResponse(
                     content={

--- a/optexity/schema/inference.py
+++ b/optexity/schema/inference.py
@@ -26,6 +26,9 @@ class InferenceRequest(BaseModel):
     per_login_parallelism: int = 1
     task_callback_url: str | None = None
     task_callback_api_key: str | None = None
+    # Optional queue priority: lower runs first, negatives allowed, None runs
+    # last. Only orders tasks within the same login / unique_parameters group.
+    priority: int | None = None
 
     @model_validator(mode="after")
     def validate_use_proxy(self):

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -129,6 +129,10 @@ class Task(BaseModel):
     company_id: CompanyID
     llm_provider: Literal["gemini", "anthropic", "openai"] = "gemini"
     llm_model_name: str = "gemini-2.5-flash"
+    # Optional queue priority: lower runs first, negatives allowed, None runs
+    # last (see priority_order_key). Only orders tasks within the same login /
+    # unique_parameters group; never across users.
+    priority: int | None = None
 
     class Config:
         json_encoders = {datetime: lambda v: v.isoformat() if v is not None else None}
@@ -152,6 +156,17 @@ class Task(BaseModel):
     @property
     def log_file_path(self) -> Path:
         return self.logs_directory / "optexity.log"
+
+    def priority_order_key(self) -> tuple[int, int, float]:
+        """Ordering key for the priority queues.
+
+        Lower runs first; None priority sorts last; ties fall back to FIFO by
+        created_at. Callers append a monotonic sequence number for a total
+        order so queue entries never compare Task objects against each other.
+        """
+        if self.priority is None:
+            return (1, 0, self.created_at.timestamp())
+        return (0, self.priority, self.created_at.timestamp())
 
     @model_validator(mode="after")
     def validate_unique_parameters(self):


### PR DESCRIPTION
Pairs with the optexity-internal opcloud change. Adds an optional integer `priority` to Task and InferenceRequest (lower runs first, negatives allowed, None runs last) and a `priority_order_key()` ordering helper. The child's local task_queue becomes a PriorityQueue so an urgent task jumps ahead of others already dispatched to the same dedicated container; a monotonic seq keeps equal-priority tasks FIFO and stops the heap comparing Task objects.