### PR TITLE
Fail task when expect_download/download_url_as_pdf produces no file

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -764,7 +764,7 @@
             "id": "docs-advanced-downloads-files",
             "path": "docs/advanced/downloads-files.mdx",
             "title": "Downloads and File Handling",
-            "summary": "Covers all file handling patterns in Optexity automations: downloading files via click (expect_download), selecting with expect_download, saving pages as PDF (download_url_as_pdf), iterating multiple downloads with for_loop_node, and uploading files with file_path. Documents storage location (/tmp/optexity/{task_id}/downloads/), download timing considerations, and best practices.",
+            "summary": "Covers all file handling patterns in Optexity automations: downloading files via click (expect_download), selecting with expect_download, saving pages as PDF (download_url_as_pdf), iterating multiple downloads with for_loop_node, and uploading files with file_path. Documents storage location (/tmp/optexity/{task_id}/downloads/), download timing considerations, failure behavior when an expected download or download_url_as_pdf produces no file (the task fails with a clear error), and best practices.",
             "gist": "File download and upload patterns: click-to-download, PDF save, multi-file loops, upload with file_path.",
             "keywords": [
                 "download",
@@ -795,8 +795,8 @@
                 "data_models": []
             },
             "reading_priority": 3,
-            "when_to_use": "Select when the query is about downloading files, uploading files, saving pages as PDF, handling multiple file downloads, or the file storage path during task execution.",
-            "embedding_hint": "download upload file PDF expect_download /tmp/optexity for_loop"
+            "when_to_use": "Select when the query is about downloading files, uploading files, saving pages as PDF, handling multiple file downloads, the file storage path during task execution, or why a task fails when an expected download produces no file.",
+            "embedding_hint": "download upload file PDF expect_download download_url_as_pdf /tmp/optexity for_loop download failure task failed no file"
         },
         {
             "id": "docs-advanced-locators",

--- a/docs/docs/advanced/downloads-files.mdx
+++ b/docs/docs/advanced/downloads-files.mdx
@@ -168,6 +168,33 @@ Optexity automatically waits for downloads when `expect_download=true`. For larg
 
 ---
 
+## Failure on Missing Download
+
+When a node expects a file but none is produced, the task **fails** rather than
+silently continuing. This applies to both download mechanisms:
+
+**`expect_download=true`** (`click_element` / `select_option`):
+
+| Condition | Task error |
+|-----------|------------|
+| No file appears within the download timeout | `could not download file when expect download is true` |
+| A file appears but is empty or missing after being saved | `file appeared but was empty/missing after move` |
+
+**`download_url_as_pdf`:**
+
+| Condition | Task error |
+|-----------|------------|
+| No URL could be resolved for the page | `could not download file for download_url_as_pdf: no URL found` |
+| The request returns a non-OK HTTP status | `could not download file for download_url_as_pdf: HTTP <status>` |
+| The saved PDF is empty or missing | `file appeared but was empty/missing after move` |
+
+<Tip>
+If a download is slow, increase `end_sleep_time` (see below) so the file has
+time to finish before the timeout triggers a failure.
+</Tip>
+
+---
+
 ## Best Practices
 
 | Practice | Recommendation |

--- a/optexity/exceptions.py
+++ b/optexity/exceptions.py
@@ -26,3 +26,14 @@ class HumanInLoopTimeoutException(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+
+class ExpectedDownloadFailedException(Exception):
+    """Raised when a node has expect_download=True but the action did not
+    produce a downloaded file. This fails the task with a fixed message."""
+
+    MESSAGE = "could not download file when expect download is true"
+
+    def __init__(self, message: str = MESSAGE):
+        super().__init__(message)
+        self.message = message

--- a/optexity/inference/core/interaction/handle_click.py
+++ b/optexity/inference/core/interaction/handle_click.py
@@ -3,6 +3,7 @@ import logging
 from optexity.exceptions import (
     AxtreeIndexActionFailedException,
     ElementNotFoundInAxtreeException,
+    ExpectedDownloadFailedException,
 )
 from optexity.inference.core.interaction.handle_command import (
     command_based_action_with_retry,
@@ -100,13 +101,21 @@ async def click_element_index(
                 )
             else:
                 await _actual_click_element()
+        except ExpectedDownloadFailedException:
+            # expect_download was True but no file was produced; fail the task
+            # with the fixed message instead of masking it as a click failure.
+            raise
         except Exception as e:
             raise AxtreeIndexActionFailedException(
                 message=f"Failed to click element at axtree index {index}",
                 index=index,
                 original_error=e,
             )
-    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+    except (
+        ElementNotFoundInAxtreeException,
+        AxtreeIndexActionFailedException,
+        ExpectedDownloadFailedException,
+    ):
         raise
     except Exception as e:
         logger.error(f"Error in click_element_index: {e}")

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -4,7 +4,10 @@ import time
 
 from playwright.async_api import Locator
 
-from optexity.exceptions import AssertLocatorPresenceException
+from optexity.exceptions import (
+    AssertLocatorPresenceException,
+    ExpectedDownloadFailedException,
+)
 from optexity.inference.core.interaction.handle_select_utils import (
     SelectOptionValue,
     smart_select,
@@ -210,6 +213,11 @@ async def command_based_action_with_retry(
             else:
                 await asyncio.sleep(max_timeout_seconds_per_try)
                 last_error = f"error: locator not visible"
+        except ExpectedDownloadFailedException:
+            # The action ran but expect_download=True produced no file. Do not
+            # retry or downgrade to a string error; fail the task with the fixed
+            # message.
+            raise
         except Exception as e:
             last_error = f"error: {e}"
             await asyncio.sleep(max_timeout_seconds_per_try)

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -5,6 +5,7 @@ from browser_use.dom.serializer.serializer import DOMTreeSerializer
 from optexity.exceptions import (
     AxtreeIndexActionFailedException,
     ElementNotFoundInAxtreeException,
+    ExpectedDownloadFailedException,
 )
 from optexity.inference.agents.select_option_prediction.select_option_prediction import (
     SelectOptionPredictionAgent,
@@ -245,13 +246,21 @@ async def select_option_index(
                 )
             else:
                 await _actual_select_option()
+        except ExpectedDownloadFailedException:
+            # expect_download was True but no file was produced; fail the task
+            # with the fixed message instead of masking it as a select failure.
+            raise
         except Exception as e:
             raise AxtreeIndexActionFailedException(
                 message=f"Failed to select option at axtree index {index}",
                 index=index,
                 original_error=e,
             )
-    except (ElementNotFoundInAxtreeException, AxtreeIndexActionFailedException):
+    except (
+        ElementNotFoundInAxtreeException,
+        AxtreeIndexActionFailedException,
+        ExpectedDownloadFailedException,
+    ):
         raise
     except Exception as e:
         logger.error(f"Error in select_option_index: {e}")

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -15,6 +15,7 @@ import playwright.async_api
 
 from optexity.exceptions import (
     ElementNotFoundInAxtreeException,
+    ExpectedDownloadFailedException,
 )
 from optexity.inference.agents.index_prediction.action_prediction_locator_axtree import (
     ActionPredictionLocatorAxtree,
@@ -756,7 +757,7 @@ async def handle_download(
             logger.error(
                 f"No new file appeared in {browser.temp_downloads_dir} within {timeout}s after download action"
             )
-            return
+            raise ExpectedDownloadFailedException()
     finally:
         for target, event_name, handler in listener_cleanup:
             try:
@@ -793,6 +794,9 @@ async def handle_download(
         memory.downloads.append(download_path)
     else:
         logger.error(f"Download file is empty or missing: {download_path}")
+        raise ExpectedDownloadFailedException(
+            "file appeared but was empty/missing after move"
+        )
 
 
 async def clean_download(download_path: Path):

--- a/optexity/inference/core/logging.py
+++ b/optexity/inference/core/logging.py
@@ -360,6 +360,21 @@ async def save_trajectory_in_server(task: Task):
         )
 
 
+def _redact_callback_data(data: dict) -> dict:
+    """Return a copy of the callback payload with secrets masked, safe to log."""
+    redacted = dict(data)
+    if redacted.get("task_callback_api_key"):
+        redacted["task_callback_api_key"] = "***"
+    callback_url = redacted.get("callback_url")
+    if isinstance(callback_url, dict):
+        callback_url = dict(callback_url)
+        for secret_key in ("api_key", "password"):
+            if callback_url.get(secret_key):
+                callback_url[secret_key] = "***"
+        redacted["callback_url"] = callback_url
+    return redacted
+
+
 async def initiate_callback(task: Task):
 
     if settings.DEPLOYMENT == "dev" and settings.LOCAL_CALLBACK_URL is not None:
@@ -412,18 +427,35 @@ async def initiate_callback(task: Task):
         if task.callback_url is not None:
             data["callback_url"] = task.callback_url.model_dump()
 
+        logger.info(
+            "Sending callback for task %s to %s with data: %s",
+            task.task_id,
+            url,
+            _redact_callback_data(data),
+        )
+
         async with httpx.AsyncClient(timeout=30.0) as client:
 
             response = await client.post(url, headers=headers, json=data)
 
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+            logger.info(
+                "Callback for task %s succeeded (status=%s): %s",
+                task.task_id,
+                response.status_code,
+                result,
+            )
+            return result
     except httpx.HTTPStatusError as e:
         logger.error(
-            f"Failed to save trajectory in server: {e.response.status_code} - {e.response.text}"
+            "Callback for task %s failed with HTTP %s: %s",
+            task.task_id,
+            e.response.status_code,
+            e.response.text,
         )
     except Exception as e:
-        logger.error(f"Failed to save trajectory in server: {e}")
+        logger.error("Callback for task %s failed: %s", task.task_id, e)
 
 
 async def save_latest_memory_state_locally(

--- a/optexity/inference/core/run_interaction.py
+++ b/optexity/inference/core/run_interaction.py
@@ -7,6 +7,7 @@ import aiofiles
 from optexity.exceptions import (
     AssertLocatorPresenceException,
     ElementNotFoundInAxtreeException,
+    ExpectedDownloadFailedException,
 )
 from optexity.inference.agents.error_handler.error_handler import ErrorHandlerAgent
 from optexity.inference.core.interaction.agentic_fallback import (
@@ -257,7 +258,9 @@ async def handle_download_url_as_pdf(
 
     if pdf_url is None:
         logger.error("No PDF URL found for current page")
-        return
+        raise ExpectedDownloadFailedException(
+            "could not download file for download_url_as_pdf: no URL found"
+        )
     download_path = (
         task.downloads_directory / download_url_as_pdf_action.download_filename
     )
@@ -266,11 +269,19 @@ async def handle_download_url_as_pdf(
 
     if not resp.ok:
         logger.error(f"Failed to download PDF: {resp.status}")
-        return
+        raise ExpectedDownloadFailedException(
+            f"could not download file for download_url_as_pdf: HTTP {resp.status}"
+        )
 
     content = await resp.body()
     async with aiofiles.open(download_path, "wb") as f:
         await f.write(content)
+
+    if not (download_path.exists() and download_path.stat().st_size > 0):
+        logger.error(f"Downloaded PDF is empty or missing: {download_path}")
+        raise ExpectedDownloadFailedException(
+            "file appeared but was empty/missing after move"
+        )
 
     memory.downloads.append(download_path)
 


### PR DESCRIPTION
Previously, download paths silently logged and continued when no file was produced. Now they raise ExpectedDownloadFailedException, which propagates uncaught to run_automation and fails the task with a clear error:

- expect_download=True, no file appeared -> "could not download file when expect download is true"
- file appeared but empty/missing after move -> "file appeared but was empty/missing after move"
- download_url_as_pdf failures (no URL, bad HTTP, empty file) -> descriptive messages

Wired the exception through the click/select/command handlers so it is not swallowed or wrapped into a generic action-failure message.