### PR TITLE
Add locator-driven iteration to for_loop_node

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -1277,21 +1277,31 @@
             "id": "docs-building-automations-for-loop-node",
             "path": "docs/building-automations/for-loop-node.mdx",
             "title": "For Loop Node",
-            "summary": "Documents the for_loop_node for iterating over a list of values in automations. Covers the variable_name property, optional index_variable_name (default index), {variable[index]} / bare {index} / {index_of(var)} substitution, nested for_loop_node support, using multiple variables (comma-separated), reset_nodes for returning browser to a known state between iterations, and on_error_in_loop error handling (continue, break, raise). Also covers data source options and the requirement that loop variables be pre-populated.",
-            "gist": "for_loop_node: iterate a variable list, nested loops, index_variable_name, {var[index]} substitution, reset_nodes, error handling.",
+            "summary": "Documents the for_loop_node for repeating actions in automations. Covers the two iteration sources: variable_name (a pre-populated list, optionally comma-separated for parallel variables) and locator (a Playwright locator whose runtime match count sets the iteration count, for tables or rows whose size is unknown when authoring). Covers optional index_variable_name (default index), item_variable_name (default item) for the current element's locator, locator_timeout, max_iterations, {variable[index]} / bare {index} / {index_of(var)} / {count_of(var)} / {count} / {item} / {item_count} substitution, templating output_variable_name to store one value per iteration, nested for_loop_node support including scoping an inner locator by the outer index, reset_nodes for returning browser to a known state between iterations, on_error_in_loop error handling (continue, break, raise), and empty-match and snapshotted-count behavior.",
+            "gist": "for_loop_node: iterate a variable list or a locator's matched elements, index_variable_name / item_variable_name placeholders, nested loops, reset_nodes, error handling.",
             "keywords": [
                 "for_loop",
                 "loop",
                 "iteration",
                 "variable_name",
+                "locator",
+                "iterate over locator",
+                "unknown count",
+                "table rows",
+                "nth",
                 "index_variable_name",
+                "item_variable_name",
+                "locator_timeout",
+                "max_iterations",
                 "nested loop",
                 "reset_nodes",
                 "on_error_in_loop",
                 "continue",
                 "break",
                 "raise",
-                "{variable[index]}"
+                "{variable[index]}",
+                "{item}",
+                "{count}"
             ],
             "document_type": "guide",
             "tags": ["building-automations", "loop", "iteration", "control-flow"],
@@ -1320,8 +1330,8 @@
                 "data_models": ["for_loop_node"]
             },
             "reading_priority": 3,
-            "when_to_use": "Select when the query is about iterating over a list in an automation, nested for_loop_node, index_variable_name, reset_nodes, error handling within loops, or the {variable[index]} syntax.",
-            "embedding_hint": "for loop nested iteration index_variable_name variable list reset_nodes on_error_in_loop control flow"
+            "when_to_use": "Select when the query is about iterating over a list in an automation, looping over every element a locator matches (e.g. every row of a table) without knowing the count in advance, nested for_loop_node, index_variable_name or item_variable_name, reset_nodes, error handling within loops, or the {variable[index]} / {item} syntax.",
+            "embedding_hint": "for loop nested iteration index_variable_name item_variable_name variable list locator count nth table rows dynamic count reset_nodes on_error_in_loop control flow"
         },
         {
             "id": "docs-building-automations-if-else-node",

--- a/docs/docs/building-automations/for-loop-node.mdx
+++ b/docs/docs/building-automations/for-loop-node.mdx
@@ -5,6 +5,13 @@ description: Iterating over multiple values in automations
 
 Use `for_loop_node` to repeat actions for each value in a list—processing search results, downloading multiple files, or clicking through items.
 
+A loop iterates over one of two sources, and exactly one must be set:
+
+| Source | Use when |
+|--------|----------|
+| `variable_name` | The values are known before the loop starts (a parameter or an earlier extraction) |
+| `locator` | The count is only known at runtime—iterate over whatever a locator matches, e.g. every row in a table |
+
 ## Structure
 
 ```json
@@ -31,8 +38,12 @@ Use `for_loop_node` to repeat actions for each value in a list—processing sear
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `variable_name` | `str` | — | Parameter to iterate over |
+| `variable_name` | `str` | — | Parameter to iterate over (mutually exclusive with `locator`) |
+| `locator` | `str` | — | Playwright locator command whose match count sets the iteration count (mutually exclusive with `variable_name`) |
 | `index_variable_name` | `str` | `"index"` | Placeholder name used in `{var[<name>]}` and bare `{<name>}` |
+| `item_variable_name` | `str` | `"item"` | Locator loops only: placeholder that expands to the current element's locator |
+| `locator_timeout` | `float` | `5.0` | Locator loops only: seconds to wait for the first match before counting |
+| `max_iterations` | `int \| null` | `null` | Cap on iterations; extra items are skipped with a warning |
 | `nodes` | `list[action_node \| for_loop_node \| if_else_node \| assert_locator_node]` | — | Actions for each iteration |
 | `reset_nodes` | `list[action_node \| for_loop_node \| if_else_node \| assert_locator_node]` | `[]` | Actions to run after each iteration |
 | `on_error_in_loop` | `"continue" \| "break" \| "raise"` | `"raise"` | Error handling behavior |
@@ -56,6 +67,8 @@ You can also use:
 | `{order_ids[index]}` | Current list value |
 | `{index_of(order_ids)}` | Current numeric index (`0`, `1`, …) |
 | `{index}` | Current numeric index (same as `index_of`, using `index_variable_name`) |
+| `{count_of(order_ids)}` | Total number of iterations |
+| `{count}` | Total number of iterations (rebound by each enclosing loop—prefer `{count_of(...)}` when nesting) |
 
 ### Using Multiple Variables in a Loop
 
@@ -110,6 +123,90 @@ Then:
 - Iteration 1 uses `{primary_var[index]}` → `"Value A1"` and `{secondary_var[index]}` → `"Value B1"`
 - Iteration 2 uses `{primary_var[index]}` → `"Value A2"` and `{secondary_var[index]}` → `"Value B2"`
 
+## Looping Over a Locator
+
+When the number of items is only known at runtime—every row of a results table, every row of a schedule—set `locator` instead of `variable_name`. The loop resolves the locator once, counts the matches, and runs the body once per match:
+
+```json
+{
+  "type": "for_loop_node",
+  "locator": "locator(\"tr.tableRowEven, tr.tableRowOdd\")",
+  "index_variable_name": "row_index",
+  "item_variable_name": "row",
+  "nodes": [
+    {
+      "type": "action_node",
+      "extraction_action": {
+        "locator": {
+          "command": "{row}.locator(\"td.PatientNameCell\")",
+          "output_variable_name": "patient_{row_index}",
+          "extraction_format": { "patient_{row_index}": "str" }
+        }
+      }
+    },
+    {
+      "type": "action_node",
+      "extraction_action": {
+        "locator": {
+          "command": "{row}.locator(\"td.TimeCell\")",
+          "output_variable_name": "time_{row_index}",
+          "extraction_format": { "time_{row_index}": "str" }
+        }
+      }
+    }
+  ],
+  "on_error_in_loop": "continue"
+}
+```
+
+This is the equivalent of:
+
+```python
+rows = page.locator("tr.tableRowEven, tr.tableRowOdd")
+
+for row_index in range(await rows.count()):
+    row = rows.nth(row_index)
+    patient = await row.locator("td.PatientNameCell").inner_text()
+    time = await row.locator("td.TimeCell").inner_text()
+```
+
+### Locator Loop Placeholders
+
+| Pattern | Expands to |
+|---------|------------|
+| `{row}` | The current element's locator, e.g. `locator("tr.tableRowEven, tr.tableRowOdd").nth(2)` |
+| `{row_index}` | Current numeric index (`0`, `1`, …) |
+| `{row_count}` | Total number of matched elements (`{item_variable_name}_count`) |
+| `{count}` | Same as `{row_count}`, but rebound by each enclosing loop |
+
+`{row}` and `{row_index}` are independent, so writing the selector out by hand works too:
+
+```json
+"command": "locator(\"tr.tableRowEven, tr.tableRowOdd\").nth({row_index}).locator(\"td.PatientNameCell\")"
+```
+
+<Tip>
+Prefer `{item_variable_name}` for anything longer than a node or two. A hand-written selector in the body can drift from the one in `locator`, and then the iteration count and the rows come from different selectors—wrong results rather than an error.
+</Tip>
+
+Because each action re-resolves its command when it runs, `nth(i)` is evaluated against the live DOM. Clicking into a row, extracting from the detail page, and returning via `reset_nodes` works as expected.
+
+### Storing One Value Per Iteration
+
+`output_variable_name` is expanded like any other placeholder, so template it (`"patient_{row_index}"`) to give each iteration its own variable. Without the placeholder, every iteration overwrites the same variable and only the last row survives. Extractions are also appended to the task's output data on every iteration regardless.
+
+### Empty Matches and Runaway Loops
+
+| Situation | Behavior |
+|-----------|----------|
+| No element matches within `locator_timeout` | Zero iterations, no error—an empty table is a valid outcome |
+| Locator command doesn't resolve | Zero iterations, logged as a warning |
+| More matches than `max_iterations` | Extra items skipped, logged as a warning |
+
+<Warning>
+The match count is taken once, when the loop starts. If the body adds or removes rows, set `max_iterations` as a guard and re-check state inside the loop rather than relying on the initial count.
+</Warning>
+
 ## Nested Loops
 
 `for_loop_node` can contain another `for_loop_node`. Give each loop a distinct `index_variable_name` so the outer index stays usable inside the inner loop:
@@ -150,6 +247,8 @@ Then:
 | Distinct names (`page_i`, `item_i`) | Outer and inner indexes can both be referenced clearly inside the innermost body. |
 
 The inner loop's list must already exist when that loop starts (for example, extract `items` inside the outer iteration before the inner `for_loop_node`).
+
+An inner loop's `locator` is itself expanded by the outer loop, so it can be scoped to the outer iteration—`"locator(\"table\").nth({page_i}).locator(\"tr\")"`. Give each locator level a distinct `item_variable_name` too, so its `{<item>_count}` stays unambiguous where bare `{count}` would not.
 
 ## Data Sources
 
@@ -305,5 +404,6 @@ Use `"continue"` when some items may fail but you want to process as many as pos
 
 ## Limitations
 
-- Variable must be populated before loop execution
+- With `variable_name`, the variable must be populated before loop execution
+- With `locator`, the match count is snapshotted when the loop starts
 - Deep nesting is allowed; keep `index_variable_name` distinct per nesting level when you need both indexes

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -519,13 +519,18 @@ def _expand_for_loop_placeholders(
     variable_names: list[str],
     index: int,
     index_variable_name: str,
+    iteration_count: int | None = None,
+    item_variable_name: str | None = None,
+    item_command: str | None = None,
 ):
     """Bind loop placeholders for one iteration onto a deep-copied node.
 
     Replacement order matters:
     1. ``{var[<index_variable_name>]}`` → ``{var[<N>]}``
     2. ``{index_of(primary)}`` → ``<N>``
-    3. bare ``{<index_variable_name>}`` → ``<N>`` (last, so it cannot
+    3. ``{<item_variable_name>}`` → the current element's locator command
+       (locator loops only)
+    4. bare ``{<index_variable_name>}`` → ``<N>`` (last, so it cannot
        corrupt ``index_of(...)`` or ``{var[...]}`` patterns)
     """
     for variable_name in variable_names:
@@ -540,7 +545,22 @@ def _expand_for_loop_placeholders(
             )
             continue
 
-    node.replace(f"{{index_of({variable_names[0]})}}", f"{index}")
+    if variable_names:
+        node.replace(f"{{index_of({variable_names[0]})}}", f"{index}")
+
+    if item_variable_name is not None and item_command is not None:
+        node.replace(f"{{{item_variable_name}}}", item_command)
+
+    if iteration_count is not None:
+        # ``{count}`` is convenient but is rebound by every enclosing loop, so
+        # nested loops should prefer a qualified form: ``{<item>_count}`` for
+        # locator loops, ``{count_of(var)}`` for variable loops.
+        if item_variable_name is not None:
+            node.replace(f"{{{item_variable_name}_count}}", f"{iteration_count}")
+        if variable_names:
+            node.replace(f"{{count_of({variable_names[0]})}}", f"{iteration_count}")
+        node.replace("{count}", f"{iteration_count}")
+
     node.replace(f"{{{index_variable_name}}}", f"{index}")
     return node
 
@@ -564,6 +584,39 @@ async def _run_for_loop_child_node(
         await run_action_node(node, task, memory, browser)
 
 
+async def _count_locator_matches(for_loop_node: ForLoopNode, browser: Browser) -> int:
+    """Number of elements a locator loop should iterate over.
+
+    Playwright's ``count()`` does not auto-wait, so give the first match a
+    chance to attach first. A locator that never attaches means zero rows,
+    which is a legitimate outcome (empty table) rather than an error.
+    """
+    assert for_loop_node.locator is not None
+    locator = await browser.get_locator_from_command(for_loop_node.locator)
+    if locator is None:
+        logger.warning(
+            f"Locator {for_loop_node.locator!r} did not resolve; "
+            "for loop will run zero iterations"
+        )
+        return 0
+
+    if for_loop_node.locator_timeout > 0:
+        try:
+            await locator.first.wait_for(
+                state="attached", timeout=for_loop_node.locator_timeout * 1000
+            )
+        except (TimeoutError, PatchrightTimeoutError, PlaywrightTimeoutError):
+            logger.info(
+                f"No element matched {for_loop_node.locator!r} within "
+                f"{for_loop_node.locator_timeout}s; for loop will run zero iterations"
+            )
+            return 0
+
+    count = await locator.count()
+    logger.debug(f"Locator {for_loop_node.locator!r} matched {count} element(s)")
+    return count
+
+
 async def handle_for_loop_node(
     for_loop_node: ForLoopNode,
     memory: Memory,
@@ -572,17 +625,47 @@ async def handle_for_loop_node(
     full_automation: list[ActionNode],
 ):
     memory.update_system_info()
-    primary_variable = for_loop_node.variable_name.split(",")[0].strip()
-    if primary_variable in task.input_parameters:
-        values = task.input_parameters[primary_variable]
-    elif primary_variable in memory.variables.generated_variables:
-        values = memory.variables.generated_variables[primary_variable]
+    item_variable_name: str | None = None
+    if for_loop_node.locator is not None:
+        # Iterating over DOM matches: the loop "values" are the per-element
+        # locator commands, which is also what gets recorded in for_loop_status.
+        item_variable_name = for_loop_node.item_variable_name
+        variable_names = []
+        values = [
+            f"{for_loop_node.locator}.nth({i})"
+            for i in range(await _count_locator_matches(for_loop_node, browser))
+        ]
     else:
-        raise ValueError(
-            f"Variable name {primary_variable} not found in input variables or generated variables"
+        assert for_loop_node.variable_name is not None
+        primary_variable = for_loop_node.variable_name.split(",")[0].strip()
+        if primary_variable in task.input_parameters:
+            values = task.input_parameters[primary_variable]
+        elif primary_variable in memory.variables.generated_variables:
+            values = memory.variables.generated_variables[primary_variable]
+        else:
+            raise ValueError(
+                f"Variable name {primary_variable} not found in input variables or generated variables"
+            )
+        variable_names = [
+            name.strip() for name in for_loop_node.variable_name.split(",")
+        ]
+
+    if (
+        for_loop_node.max_iterations is not None
+        and len(values) > for_loop_node.max_iterations
+    ):
+        logger.warning(
+            f"For loop source has {len(values)} items but max_iterations is "
+            f"{for_loop_node.max_iterations}; skipping the remaining "
+            f"{len(values) - for_loop_node.max_iterations} item(s)"
         )
-    variable_names = [name.strip() for name in for_loop_node.variable_name.split(",")]
+        values = values[: for_loop_node.max_iterations]
+
+    iteration_count = len(values)
     index_variable_name = for_loop_node.index_variable_name
+    # ForLoopStatus needs a name for the thing being looped over; a locator
+    # loop has no variable, so report the locator command itself.
+    loop_label = for_loop_node.variable_name or for_loop_node.locator or ""
     memory.variables.for_loop_status.append([])
     for index in range(len(values)):
 
@@ -593,25 +676,26 @@ async def handle_for_loop_node(
                     variable_names,
                     index,
                     index_variable_name,
+                    iteration_count=iteration_count,
+                    item_variable_name=item_variable_name,
+                    item_command=values[index] if item_variable_name else None,
                 )
                 await _run_for_loop_child_node(
                     new_node, memory, task, browser, full_automation
                 )
             memory.variables.for_loop_status[-1].append(
                 ForLoopStatus(
-                    variable_name=for_loop_node.variable_name,
+                    variable_name=loop_label,
                     index=index,
                     value=values[index],
                     status="success",
                 )
             )
         except Exception as e:
-            logger.error(
-                f"Error running for loop node {for_loop_node.variable_name}: {e}"
-            )
+            logger.error(f"Error running for loop node {loop_label}: {e}")
             memory.variables.for_loop_status[-1].append(
                 ForLoopStatus(
-                    variable_name=for_loop_node.variable_name,
+                    variable_name=loop_label,
                     index=index,
                     value=values[index],
                     status="error",
@@ -624,7 +708,7 @@ async def handle_for_loop_node(
                 for index2 in range(index + 1, len(values)):
                     memory.variables.for_loop_status[-1].append(
                         ForLoopStatus(
-                            variable_name=for_loop_node.variable_name,
+                            variable_name=loop_label,
                             index=index2,
                             value=values[index2],
                             status="skipped",
@@ -644,6 +728,9 @@ async def handle_for_loop_node(
                     variable_names,
                     index,
                     index_variable_name,
+                    iteration_count=iteration_count,
+                    item_variable_name=item_variable_name,
+                    item_command=values[index] if item_variable_name else None,
                 )
                 await _run_for_loop_child_node(
                     new_node, memory, task, browser, full_automation

--- a/optexity/schema/actions/extraction_action.py
+++ b/optexity/schema/actions/extraction_action.py
@@ -211,6 +211,18 @@ class LocatorExtraction(BaseModel):
 
     def replace(self, pattern: str, replacement: str):
         self.command = self.command.replace(pattern, replacement)
+        # Inside a loop, the storage key is usually templated too (e.g.
+        # "patient_{row_index}") so each iteration lands in its own variable.
+        # The format keys are rewritten alongside it to keep
+        # output_variable_name a valid key for the LLM fallback path.
+        if self.output_variable_name:
+            self.output_variable_name = self.output_variable_name.replace(
+                pattern, replacement
+            )
+            self.extraction_format = {
+                key.replace(pattern, replacement): value
+                for key, value in self.extraction_format.items()
+            }
         return self
 
 

--- a/optexity/schema/automation.py
+++ b/optexity/schema/automation.py
@@ -246,13 +246,69 @@ class ActionNode(BaseModel):
 
 
 class ForLoopNode(BaseModel):
-    # Loops through range of values of {variable_name[<index_variable_name>]}
+    # Two iteration sources, exactly one of which must be set: variable_name
+    # (values known before the loop starts) or locator (DOM matches, count only
+    # known at runtime). Field descriptions are consumed by the workflow
+    # authoring agent via TypeAdapter(...).json_schema(), so keep them accurate.
     type: Literal["for_loop_node"]
-    variable_name: str
-    # Placeholder name used in {var[<name>]} / bare {<name>}. Defaults to
-    # "index" for backward compatibility. Use distinct names when nesting loops
-    # so the outer index remains addressable inside the inner loop.
-    index_variable_name: str = "index"
+    variable_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the list variable to iterate over; its length is the "
+            "iteration count. Comma-separated names iterate in parallel, with "
+            "the first one setting the length. Reference values in the loop "
+            "body as {variable_name[<index_variable_name>]}. Mutually "
+            "exclusive with locator: exactly one of the two must be set."
+        ),
+    )
+    locator: str | None = Field(
+        default=None,
+        description=(
+            "Playwright locator command evaluated against `page` (same grammar "
+            "as assert_locator_node.locator), e.g. 'locator(\"tr.rowEven, "
+            "tr.rowOdd\")'. The number of matched elements is the iteration "
+            "count, so use this to loop over rows/items whose count is not "
+            "known when authoring. Mutually exclusive with variable_name: "
+            "exactly one of the two must be set."
+        ),
+    )
+    index_variable_name: str = Field(
+        default="index",
+        description=(
+            "Placeholder name bound to the current iteration's number, used as "
+            "{var[<name>]} and bare {<name>}. Use distinct names when nesting "
+            "loops so the outer index remains addressable inside the inner "
+            "loop. Must not be 'index_of', 'count_of' or 'count' (reserved for "
+            "the {index_of(var)}, {count_of(var)} and {count} placeholders), "
+            "and must not match a name listed in variable_name."
+        ),
+    )
+    item_variable_name: str = Field(
+        default="item",
+        description=(
+            "Locator loops only: placeholder bound to the current element's "
+            'locator, e.g. {item} -> locator("tr.rowEven, tr.rowOdd").nth(3). '
+            "Scope body commands off it: '{item}.locator(\"td.NameCell\")'. "
+            "{<item_variable_name>_count} is bound to the total number of "
+            "matches. Must differ from index_variable_name."
+        ),
+    )
+    locator_timeout: float = Field(
+        default=5.0,
+        description=(
+            "Locator loops only: seconds to wait for the first match to attach "
+            "before counting (Playwright's count() does not auto-wait). A "
+            "locator that never attaches yields zero iterations rather than an "
+            "error, so an empty table is handled without failing the run."
+        ),
+    )
+    max_iterations: int | None = Field(
+        default=None,
+        description=(
+            "Cap on the number of iterations; extra items are skipped with a "
+            "warning. Null means iterate over everything the source provides."
+        ),
+    )
     nodes: list[
         Annotated[
             ActionNode | IfElseNodeRef | ForLoopNodeRef | AssertLocatorNodeRef,
@@ -268,24 +324,57 @@ class ForLoopNode(BaseModel):
     on_error_in_loop: Literal["continue", "break", "raise"] = "raise"
 
     @model_validator(mode="after")
+    def validate_iteration_source(self):
+        if (self.variable_name is None) == (self.locator is None):
+            raise ValueError("Exactly one of variable_name or locator must be provided")
+        if self.locator is not None:
+            if not self.locator.strip():
+                raise ValueError("locator must not be empty")
+            if self.locator_timeout < 0:
+                raise ValueError("locator_timeout must not be negative")
+        if self.max_iterations is not None and self.max_iterations <= 0:
+            raise ValueError("max_iterations must be greater than 0")
+        return self
+
+    @model_validator(mode="after")
     def validate_index_variable_name(self):
-        name = self.index_variable_name
-        if not name or not name.isidentifier():
-            raise ValueError(
-                f"index_variable_name {name!r} must be a valid Python identifier"
-            )
-        if name == "index_of":
-            raise ValueError(
-                "index_variable_name cannot be 'index_of' (reserved for "
-                "{index_of(variable)} placeholders)"
-            )
         loop_vars = {
-            part.strip() for part in self.variable_name.split(",") if part.strip()
+            part.strip()
+            for part in (self.variable_name or "").split(",")
+            if part.strip()
         }
-        if name in loop_vars:
+        names = {"index_variable_name": self.index_variable_name}
+        if self.locator is not None:
+            names["item_variable_name"] = self.item_variable_name
+
+        # Reserved because the runtime binds {index_of(var)}, {count_of(var)}
+        # and bare {count} itself; reusing these names would silently shadow
+        # them (e.g. index_variable_name "count" would resolve {count} to the
+        # iteration count rather than the current index).
+        reserved = {"index_of", "count_of", "count"}
+
+        for field, name in names.items():
+            if not name or not name.isidentifier():
+                raise ValueError(f"{field} {name!r} must be a valid Python identifier")
+            if name in reserved:
+                raise ValueError(
+                    f"{field} cannot be {name!r} (reserved for "
+                    "{index_of(variable)} / {count_of(variable)} / {count} "
+                    "placeholders)"
+                )
+            if name in loop_vars:
+                raise ValueError(
+                    f"{field} {name!r} must not match a name in "
+                    f"variable_name {self.variable_name!r}"
+                )
+
+        if (
+            self.locator is not None
+            and self.item_variable_name == self.index_variable_name
+        ):
             raise ValueError(
-                f"index_variable_name {name!r} must not match a name in "
-                f"variable_name {self.variable_name!r}"
+                "item_variable_name must differ from index_variable_name "
+                f"(both are {self.index_variable_name!r})"
             )
         return self
 
@@ -296,6 +385,12 @@ class ForLoopNode(BaseModel):
         the runtime expects a `.replace()` method (e.g. loop expansion).
         """
         replacement_str = "" if replacement is None else str(replacement)
+
+        # A nested locator loop can be scoped by the enclosing loop, e.g.
+        # 'locator("table").nth({page_i}).locator("tr")', so the locator
+        # command itself takes part in placeholder expansion.
+        if self.locator is not None:
+            self.locator = self.locator.replace(pattern, replacement_str)
 
         for node in self.nodes:
             if hasattr(node, "replace"):


### PR DESCRIPTION
for_loop_node could only iterate over a variable whose length was known before the loop started, so looping over "every row this table happens to have" required knowing the count up front. There was no way to get a locator's match count into a variable either: python_script_action receives `page` but has no channel back into memory.variables.

ForLoopNode now accepts either variable_name (unchanged) or a new `locator` field, whose runtime match count sets the iteration count. Exactly one of the two must be set. The body binds:

  {item}        -> locator("tr.rowEven, tr.rowOdd").nth(3)
  {item_count}  -> total matches, also as bare {count}
  {index}       -> current index, as before

so a body command reads '{item}.locator("td.PatientNameCell")'. Each action re-resolves its command when it runs, so nth(i) is evaluated against the live DOM and click-into-row / reset_nodes flows still work.

Supporting changes:

- count() does not auto-wait, so wait for the first match to attach (locator_timeout, default 5s) before counting. A locator that never attaches yields zero iterations rather than an error, since an empty table is a legitimate outcome.
- max_iterations caps either source, logging what it skipped.
- ForLoopNode.replace() now rewrites self.locator, so a nested locator loop can be scoped by its parent: locator("table").nth({page_i})...
- LocatorExtraction.replace() now templates output_variable_name (and the matching extraction_format keys), so "patient_{row_index}" gives each iteration its own variable instead of every row overwriting one.
- index_variable_name / item_variable_name reject 'count', 'count_of' and 'index_of', which would silently shadow those placeholders.
- New ForLoopNode fields carry Field(description=...) because opbackend's workflow authoring agent embeds TypeAdapter(...).json_schema() in its prompt, and Python comments do not reach the generated schema.

Docs and docs-manifest.json updated so the new source is discoverable.