### PR TITLE
feat: attach freeform metadata to expect_download files

### DIFF
--- a/docs/api-reference/callback.mdx
+++ b/docs/api-reference/callback.mdx
@@ -15,6 +15,7 @@ The callback response is a JSON object with the following fields:
 - `error`: string indicating the error message. If there is no error, it will be `null`.
 - `final_screenshot`: base64 encoded string of the final screenshot
 - `downloads`: list of download objects. Each object has a `url` and a `filename` field.
+- `downloads_with_metadata`: optional list included only when at least one download has metadata. Each object has `url`, `filename`, and `metadata` (`null` when that file has none). Omitted entirely when no download metadata was set.
 
 ```json
 {
@@ -29,6 +30,13 @@ The callback response is a JSON object with the following fields:
         {
             "url": "signed url",
             "filename": "filename"
+        }
+    ],
+    "downloads_with_metadata": [
+        {
+            "url": "signed url",
+            "filename": "filename",
+            "metadata": { "doc_id": "123" }
         }
     ]
 }

--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -103,7 +103,7 @@
             "id": "api-reference-callback",
             "path": "api-reference/callback.mdx",
             "title": "Callback Reference",
-            "summary": "Complete reference for the callback payload Optexity sends to a user-configured endpoint when an automation task completes. Documents all top-level fields: status, task_id, recording_id, output_data, error, final_screenshot, and downloads. Includes a full example JSON payload.",
+            "summary": "Complete reference for the callback payload Optexity sends to a user-configured endpoint when an automation task completes. Documents all top-level fields: status, task_id, recording_id, output_data, error, final_screenshot, downloads, and optional downloads_with_metadata. Includes a full example JSON payload.",
             "gist": "Full schema of the HTTP POST payload sent to your callback URL on task completion.",
             "keywords": [
                 "callback",
@@ -113,6 +113,7 @@
                 "status",
                 "output_data",
                 "downloads",
+                "downloads_with_metadata",
                 "final_screenshot",
                 "schema"
             ],
@@ -135,11 +136,16 @@
             "entities": {
                 "systems": ["Optexity cloud"],
                 "apis": ["callback endpoint"],
-                "data_models": ["callback payload", "output_data", "downloads"]
+                "data_models": [
+                    "callback payload",
+                    "output_data",
+                    "downloads",
+                    "downloads_with_metadata"
+                ]
             },
             "reading_priority": 3,
             "when_to_use": "Select when the query is about the shape or fields of the callback/webhook payload received after a task completes, or when debugging what fields are returned in a callback.",
-            "embedding_hint": "callback webhook payload schema task completion output_data downloads"
+            "embedding_hint": "callback webhook payload schema task completion output_data downloads downloads_with_metadata"
         },
         {
             "id": "api-reference-inference-endpoint",
@@ -726,7 +732,7 @@
             "id": "docs-advanced-callbacks",
             "path": "docs/advanced/callbacks.mdx",
             "title": "Callbacks",
-            "summary": "Explains how to receive HTTP POST notifications when automations complete. Covers local development setup via the LOCAL_CALLBACK_URL environment variable, production configuration through the Optexity dashboard, the callback payload structure (task_id, status, output_data, downloads), and authentication options (API key, Basic Auth). Links to the Callback Reference for the complete schema.",
+            "summary": "Explains how to receive HTTP POST notifications when automations complete. Covers local development setup via the LOCAL_CALLBACK_URL environment variable, production configuration through the Optexity dashboard, the callback payload structure (task_id, status, output_data, downloads, optional downloads_with_metadata), and authentication options (API key, Basic Auth). Links to the Callback Reference for the complete schema.",
             "gist": "HTTP callback setup for automation completion: local dev vs production, payload overview, authentication.",
             "keywords": [
                 "callback",
@@ -737,7 +743,8 @@
                 "API key",
                 "Basic Auth",
                 "notification",
-                "task completion"
+                "task completion",
+                "downloads_with_metadata"
             ],
             "document_type": "guide",
             "tags": ["advanced", "callbacks", "webhook", "integration"],
@@ -747,6 +754,10 @@
                     {
                         "doc_id": "api-reference-callback",
                         "context": "Links to callback reference for the complete payload schema."
+                    },
+                    {
+                        "doc_id": "docs-advanced-downloads-files",
+                        "context": "Download metadata on expect_download populates downloads_with_metadata."
                     }
                 ],
                 "referenced_by": [
@@ -759,22 +770,23 @@
             "entities": {
                 "systems": ["Optexity dashboard"],
                 "apis": [],
-                "data_models": ["callback payload"]
+                "data_models": ["callback payload", "downloads_with_metadata"]
             },
             "reading_priority": 3,
             "when_to_use": "Select when the query is about setting up callbacks/webhooks, receiving notifications on task completion, configuring LOCAL_CALLBACK_URL, or authenticating callback requests.",
-            "embedding_hint": "callback webhook notification task completion LOCAL_CALLBACK_URL authentication"
+            "embedding_hint": "callback webhook notification task completion LOCAL_CALLBACK_URL authentication downloads_with_metadata"
         },
         {
             "id": "docs-advanced-downloads-files",
             "path": "docs/advanced/downloads-files.mdx",
             "title": "Downloads and File Handling",
-            "summary": "Covers all file handling patterns in Optexity automations: downloading files via click (expect_download), selecting with expect_download, saving pages as PDF (download_url_as_pdf), iterating multiple downloads with for_loop_node (over a variable list, or over a locator's matched rows using the loop index for unique filenames), and uploading files with file_path. Documents storage location (/tmp/optexity/{task_id}/downloads/), download timing considerations, failure behavior when an expected download or download_url_as_pdf produces no file (the task fails with a clear error), and best practices.",
-            "gist": "File download and upload patterns: click-to-download, PDF save, multi-file loops, upload with file_path.",
+            "summary": "Covers all file handling patterns in Optexity automations: downloading files via click (expect_download), selecting with expect_download, attaching freeform download_metadata, saving pages as PDF (download_url_as_pdf), iterating multiple downloads with for_loop_node (over a variable list, or over a locator's matched rows using the loop index for unique filenames), and uploading files with file_path. Documents storage location (/tmp/optexity/{task_id}/downloads/), download timing considerations, failure behavior when an expected download or download_url_as_pdf produces no file (the task fails with a clear error), and best practices.",
+            "gist": "File download and upload patterns: click-to-download, metadata, PDF save, multi-file loops, upload with file_path.",
             "keywords": [
                 "download",
                 "upload",
                 "expect_download",
+                "download_metadata",
                 "file_path",
                 "download_url_as_pdf",
                 "PDF",
@@ -792,6 +804,10 @@
                     {
                         "doc_id": "docs-building-automations-for-loop-node",
                         "context": "Multiple downloads use for_loop_node."
+                    },
+                    {
+                        "doc_id": "docs-advanced-callbacks",
+                        "context": "download_metadata appears on callbacks as downloads_with_metadata."
                     }
                 ],
                 "referenced_by": []
@@ -799,11 +815,11 @@
             "entities": {
                 "systems": [],
                 "apis": [],
-                "data_models": []
+                "data_models": ["download_metadata"]
             },
             "reading_priority": 3,
-            "when_to_use": "Select when the query is about downloading files, uploading files, saving pages as PDF, handling multiple file downloads, the file storage path during task execution, or why a task fails when an expected download produces no file.",
-            "embedding_hint": "download upload file PDF expect_download download_url_as_pdf /tmp/optexity for_loop download failure task failed no file"
+            "when_to_use": "Select when the query is about downloading files, uploading files, saving pages as PDF, attaching download metadata, handling multiple file downloads, the file storage path during task execution, or why a task fails when an expected download produces no file.",
+            "embedding_hint": "download upload file PDF expect_download download_metadata download_url_as_pdf /tmp/optexity for_loop download failure task failed no file"
         },
         {
             "id": "docs-advanced-locators",

--- a/docs/docs/action-types/interaction-action.mdx
+++ b/docs/docs/action-types/interaction-action.mdx
@@ -62,6 +62,7 @@ Use `command` for deterministic element finding (fast, no LLM tokens). The AI us
 | `double_click` | `bool` | `False` | Double-click instead of single |
 | `expect_download` | `bool` | `False` | Click triggers file download |
 | `download_filename` | `str \| None` | Auto-generated | Filename for download |
+| `download_metadata` | `dict \| None` | `None` | Freeform JSON stored with the download |
 
 ### Examples
 
@@ -167,6 +168,7 @@ If `input_text` references an empty variable, the action is skipped automaticall
 | `select_values` | `list[str]` | Required | Values to select |
 | `expect_download` | `bool` | `False` | Selection triggers download |
 | `download_filename` | `str \| None` | Auto-generated | Filename for download |
+| `download_metadata` | `dict \| None` | `None` | Freeform JSON stored with the download |
 
 <Tip>
 Optexity supports fuzzy matching for select values—"United States" will match "UNITED STATES OF AMERICA".

--- a/docs/docs/advanced/callbacks.mdx
+++ b/docs/docs/advanced/callbacks.mdx
@@ -54,6 +54,13 @@ Configure in the Optexity dashboard:
   "final_screenshot": "base64_encoded_string",
   "downloads": [
     {"url": "signed_url", "filename": "report.pdf"}
+  ],
+  "downloads_with_metadata": [
+    {
+      "url": "signed_url",
+      "filename": "report.pdf",
+      "metadata": {"doc_id": "123", "kind": "report"}
+    }
   ]
 }
 ```
@@ -66,6 +73,9 @@ Configure in the Optexity dashboard:
 | `error` | `str \| null` | Error message if failed |
 | `final_screenshot` | `str` | Base64 screenshot |
 | `downloads` | `list` | Download URLs and filenames |
+| `downloads_with_metadata` | `list \| omitted` | All downloads with optional `metadata`; only present when at least one file has metadata |
+
+Set `download_metadata` on `expect_download` actions to populate this. See [Downloads & Files](/docs/advanced/downloads-files).
 
 ---
 

--- a/docs/docs/advanced/downloads-files.mdx
+++ b/docs/docs/advanced/downloads-files.mdx
@@ -33,6 +33,32 @@ Optexity can download files from websites and upload files to forms.
 |----------|------|---------|-------------|
 | `expect_download` | `bool` | `False` | Action triggers download |
 | `download_filename` | `str \| None` | Auto-generated UUID | Filename for download |
+| `download_metadata` | `dict \| None` | `None` | Freeform JSON stored with the download |
+
+---
+
+## Download Metadata
+
+Attach freeform JSON to a download when using `expect_download`. Values support the same `{variable}` substitution as other action fields:
+
+```json
+{
+  "interaction_action": {
+    "click_element": {
+      "command": "get_by_text(\"{doc_ids[index]}\")",
+      "expect_download": true,
+      "download_filename": "doc_{doc_ids[index]}.pdf",
+      "download_metadata": {
+        "doc_id": "{doc_ids[index]}",
+        "source": "ehr",
+        "kind": "report"
+      }
+    }
+  }
+}
+```
+
+Metadata is keyed by the final filename and returned on callbacks as optional `downloads_with_metadata` (see [Callbacks](/docs/advanced/callbacks)). Only `click_element` / `select_option` with `expect_download` support this field.
 
 ---
 

--- a/optexity/inference/core/interaction/handle_click.py
+++ b/optexity/inference/core/interaction/handle_click.py
@@ -98,6 +98,7 @@ async def click_element_index(
                     browser,
                     task,
                     click_element_action.download_filename,
+                    click_element_action.download_metadata,
                 )
             else:
                 await _actual_click_element()

--- a/optexity/inference/core/interaction/handle_command.py
+++ b/optexity/inference/core/interaction/handle_command.py
@@ -326,7 +326,12 @@ async def click_locator(
 
     if click_element_action.expect_download:
         await handle_download(
-            _actual_click, memory, browser, task, click_element_action.download_filename
+            _actual_click,
+            memory,
+            browser,
+            task,
+            click_element_action.download_filename,
+            click_element_action.download_metadata,
         )
     else:
         await _actual_click()
@@ -443,6 +448,7 @@ async def select_option_locator(
             browser,
             task,
             select_option_action.download_filename,
+            select_option_action.download_metadata,
         )
     else:
         await _actual_select_option()

--- a/optexity/inference/core/interaction/handle_select.py
+++ b/optexity/inference/core/interaction/handle_select.py
@@ -243,6 +243,7 @@ async def select_option_index(
                     browser,
                     task,
                     select_option_action.download_filename,
+                    select_option_action.download_metadata,
                 )
             else:
                 await _actual_select_option()

--- a/optexity/inference/core/interaction/utils.py
+++ b/optexity/inference/core/interaction/utils.py
@@ -7,7 +7,7 @@ import shutil
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, Union
+from typing import Any, Callable, Union
 
 import aiofiles
 import patchright.async_api
@@ -624,9 +624,28 @@ async def _wait_for_file_stable(
 
 
 async def handle_download(
-    func: Callable, memory: Memory, browser: Browser, task: Task, download_filename: str
+    func: Callable,
+    memory: Memory,
+    browser: Browser,
+    task: Task,
+    download_filename: str,
+    download_metadata: dict[str, Any] | None = None,
 ):
     download_path: Path = task.downloads_directory / download_filename
+
+    def _register_download_metadata(filename: str) -> None:
+        if download_metadata is None:
+            return
+        try:
+            memory.download_metadata[filename] = download_metadata
+            logger.info(
+                f"handle_download: registered metadata for {filename!r}: "
+                f"{download_metadata}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"handle_download: failed to register metadata for {filename!r}: {e}"
+            )
 
     before = _snapshot_dir(browser.temp_downloads_dir)
 
@@ -653,6 +672,8 @@ async def handle_download(
         name (e.g. "401002157.pdf" instead of "<uuid>.pdf")."""
         new_indices = list(range(urls_before, len(memory.urls_to_downloads)))
         if not new_indices:
+            # raw_downloads channel: file name finalized later; key by requested name
+            _register_download_metadata(download_filename)
             return
         for pos, i in enumerate(new_indices):
             url, auto_name = memory.urls_to_downloads[i]
@@ -665,6 +686,7 @@ async def handle_download(
                 p = Path(desired)
                 desired = f"{p.stem}_{pos}{p.suffix}"
             memory.urls_to_downloads[i] = (url, desired)
+            _register_download_metadata(desired)
             logger.info(
                 f"handle_download: renamed captured download "
                 f"{auto_name!r} -> {desired!r}"
@@ -848,6 +870,7 @@ async def handle_download(
 
     if download_path.exists() and download_path.stat().st_size > 0:
         memory.downloads.append(download_path)
+        _register_download_metadata(download_path.name)
     else:
         logger.error(f"Download file is empty or missing: {download_path}")
         raise ExpectedDownloadFailedException(

--- a/optexity/inference/core/logging.py
+++ b/optexity/inference/core/logging.py
@@ -277,12 +277,24 @@ async def save_downloads_in_server(task: Task, memory: Memory):
         if len(uploaded_filenames) == 0:
             return
 
+        confirm_payload: dict = {
+            "task_id": task.task_id,
+            "filenames": uploaded_filenames,
+        }
+        downloads_metadata = {
+            name: memory.download_metadata[name]
+            for name in uploaded_filenames
+            if name in memory.download_metadata
+        }
+        if downloads_metadata:
+            confirm_payload["downloads_metadata"] = downloads_metadata
+
         confirm_url = urljoin(settings.SERVER_URL, settings.CONFIRM_DOWNLOADS_ENDPOINT)
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 confirm_url,
                 headers=headers,
-                json={"task_id": task.task_id, "filenames": uploaded_filenames},
+                json=confirm_payload,
             )
             response.raise_for_status()
             response_json = response.json()

--- a/optexity/schema/actions/interaction_action.py
+++ b/optexity/schema/actions/interaction_action.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from optexity.schema.actions.keyboard_keys import KEY_NAMES
 from optexity.schema.actions.prompts import overlay_popup_prompt
+from optexity.utils.utils import deep_replace
 
 
 class Locator(BaseModel):
@@ -118,6 +119,7 @@ class SelectOptionAction(BaseAction):
     select_values: list[str] | None = None
     expect_download: bool = False
     download_filename: str | None = None
+    download_metadata: dict[str, Any] | None = None
 
     @model_validator(mode="after")
     def set_download_filename(self):
@@ -138,12 +140,17 @@ class SelectOptionAction(BaseAction):
             self.download_filename = self.download_filename.replace(
                 pattern, replacement
             ).strip('"')
+        if self.download_metadata is not None:
+            self.download_metadata = deep_replace(
+                self.download_metadata, pattern, replacement
+            )
 
 
 class ClickElementAction(BaseAction):
     double_click: bool = False
     expect_download: bool = False
     download_filename: str | None = None
+    download_metadata: dict[str, Any] | None = None
     button: Literal["left", "right", "middle"] = "left"
     mouse_click: bool = False
     mouse_click_deviation: dict[str, float | int] | None = None
@@ -177,6 +184,10 @@ class ClickElementAction(BaseAction):
             self.download_filename = self.download_filename.replace(
                 pattern, replacement
             ).strip('"')
+        if self.download_metadata is not None:
+            self.download_metadata = deep_replace(
+                self.download_metadata, pattern, replacement
+            )
 
 
 class InputTextAction(BaseAction):

--- a/optexity/schema/callback.py
+++ b/optexity/schema/callback.py
@@ -14,5 +14,8 @@ class CallbackResponse(BaseModel):
     final_screenshot: str | None = None
     endpoint_name: str
     downloads: list[dict] | None = None
+    # Present only when at least one download has metadata; includes all files
+    # with metadata=null where absent. Entries: {url, filename, metadata}.
+    downloads_with_metadata: list[dict] | None = None
     input_parameters: dict[str, list[str | int | float | bool]] | None = None
     unique_parameter_names: list[str] | None = None

--- a/optexity/schema/memory.py
+++ b/optexity/schema/memory.py
@@ -159,6 +159,9 @@ class Memory(BaseModel):
     )
     urls_to_downloads: list[tuple[str, str]] = Field(default_factory=list)
     downloads: list[Path] = Field(default_factory=list)
+    # Sparse map of final download filename -> freeform metadata from
+    # expect_download actions that set download_metadata.
+    download_metadata: dict[str, dict[str, Any]] = Field(default_factory=dict)
     final_screenshot: str | None = Field(default=None)
     system_info_tracking: list[SystemInfo] = Field(default_factory=list)
     unique_child_arn: str

--- a/optexity/schema/task.py
+++ b/optexity/schema/task.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from PIL import Image
 from pydantic import BaseModel, Field, computed_field, model_validator
@@ -319,3 +319,4 @@ class RequestDownloadUploadUrlsRequest(BaseModel):
 class ConfirmDownloadsRequest(BaseModel):
     task_id: str
     filenames: list[str]
+    downloads_metadata: dict[str, dict[str, Any]] | None = None


### PR DESCRIPTION
Allow download_metadata on click/select downloads, carry it through confirm, and document optional downloads_with_metadata on callbacks.