### PR TITLE
feat: add misc_action.count_locator for page match counts

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -515,6 +515,49 @@
             "embedding_hint": "llm query misc action direct prompt classify transform structured output no browser in-memory"
         },
         {
+            "id": "docs-action-types-count-locator-action",
+            "path": "docs/action-types/count-locator-action.mdx",
+            "title": "Count Locator Action",
+            "summary": "Documents misc_action.count_locator — counts Playwright locator matches on the current page and stores the integer in generated_variables. Covers locator, name, locator_timeout, stable-count wait semantics shared with locator for-loops, and when to use count_locator vs a locator for_loop_node.",
+            "gist": "Count how many elements a Playwright locator matches and store the result as a generated variable for branching or thresholds.",
+            "keywords": [
+                "count_locator",
+                "CountLocatorAction",
+                "misc_action",
+                "locator",
+                "locator_timeout",
+                "count",
+                "generated_variables",
+                "Playwright",
+                "match count",
+                "stable count"
+            ],
+            "document_type": "guide",
+            "tags": ["action-types", "misc-action", "locators", "playwright"],
+            "relationships": {
+                "depends_on": ["docs-building-automations-action-node"],
+                "references": [
+                    {
+                        "doc_id": "docs-building-automations-for-loop-node",
+                        "context": "Locator for-loops share locator_timeout and stable-count wait semantics; use a for-loop when iterating matches instead of only counting."
+                    },
+                    {
+                        "doc_id": "docs-advanced-locators",
+                        "context": "Locator command grammar is documented there."
+                    }
+                ],
+                "referenced_by": []
+            },
+            "entities": {
+                "systems": ["Playwright"],
+                "apis": [],
+                "data_models": ["CountLocatorAction", "MiscAction"]
+            },
+            "reading_priority": 2,
+            "when_to_use": "Select when the query is about misc_action.count_locator, counting Playwright locator matches on a page, storing a match count in generated_variables, locator_timeout for counting, or choosing between count_locator and a locator for_loop_node.",
+            "embedding_hint": "count locator misc action match count generated_variables locator_timeout stable count pagination empty table"
+        },
+        {
             "id": "docs-action-types-sleep-action",
             "path": "docs/action-types/sleep-action.mdx",
             "title": "Sleep Action",
@@ -1349,6 +1392,10 @@
                     {
                         "doc_id": "docs-building-automations-automation-structure",
                         "context": "Automation structure lists for_loop_node as a node type."
+                    },
+                    {
+                        "doc_id": "docs-action-types-count-locator-action",
+                        "context": "count_locator shares locator counting semantics and links here for for-loop comparison."
                     }
                 ]
             },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
                                 "pages": [
                                     "/docs/action-types/python-script-action",
                                     "/docs/action-types/llm-query-action",
+                                    "/docs/action-types/count-locator-action",
                                     "/docs/action-types/human-in-loop"
                                 ]
                             },

--- a/docs/docs/action-types/count-locator-action.mdx
+++ b/docs/docs/action-types/count-locator-action.mdx
@@ -1,0 +1,66 @@
+---
+title: Count Locator Action
+description: Count how many elements a Playwright locator matches on the current page
+---
+
+Use `misc_action.count_locator` to count Playwright locator matches on the current page and store the integer in `generated_variables`—useful for pagination checks, empty-state branches, or capping loops.
+
+## Overview
+
+- **Use when**: You need the match count as a variable (e.g. decide whether to paginate, skip an empty table, or compare against a threshold) without iterating over the matches.
+- **Execution**: Resolves `locator` against the live page, waits for the first match to attach (optional timeout), then waits until the match count is stable for 1s before storing the result.
+- **Same counting semantics as locator for-loops**: See [For Loop Node](/docs/building-automations/for-loop-node) for `locator_timeout` and the stable-count wait.
+
+## Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `locator` | `str` | Required | Playwright locator command evaluated against `page`, e.g. `get_by_role("row")` |
+| `name` | `str` | Required | Key written into `generated_variables` as a single-element list `[count]` |
+| `locator_timeout` | `float` | `5.0` | Seconds to wait for the first match to attach before counting; `0` skips the attach wait |
+
+## JSON Example
+
+```json
+{
+  "type": "action_node",
+  "misc_action": {
+    "count_locator": {
+      "locator": "get_by_role(\"row\")",
+      "name": "row_count"
+    }
+  }
+}
+```
+
+After this action, `{row_count[0]}` is available in subsequent nodes (including `if_else_node` conditions and `set_variable` expressions).
+
+## Waiting for Matches
+
+Playwright's `count()` does not auto-wait. Without `locator_timeout`, an asynchronously rendered table can count as empty. Defaults match locator for-loops: wait up to 5s for the first match, then require the count to stay unchanged for 1s so streaming rows are included.
+
+```json
+{
+  "misc_action": {
+    "count_locator": {
+      "locator": "locator(\"table tbody tr\")",
+      "name": "result_rows",
+      "locator_timeout": 10.0
+    }
+  }
+}
+```
+
+Zero matches is a valid result: the action stores `0` (with a warning) rather than failing the run.
+
+## Count Locator vs Locator For-Loop
+
+| | `misc_action.count_locator` | `for_loop_node` with `locator` |
+|--|----------------------------|--------------------------------|
+| Purpose | Store match count as a variable | Iterate once per match |
+| Output | `generated_variables[name] = [count]` | Body runs `count` times; `{locator[index]}` expands to `.nth(N)` |
+| Typical use | Branching, thresholds, logging | Process every row/item |
+
+<Tip>
+Use `count_locator` when you only need the number. Use a locator for-loop when you need to act on each match.
+</Tip>

--- a/optexity/inference/core/run_automation.py
+++ b/optexity/inference/core/run_automation.py
@@ -39,6 +39,7 @@ from optexity.inference.core.run_interaction import (
     run_interaction_action,
 )
 from optexity.inference.core.run_misc import (
+    run_count_locator_action,
     run_fail_state_action,
     run_llm_query_action,
     run_set_variable_action,
@@ -472,6 +473,8 @@ async def run_action_node(
                 await run_set_variable_action(misc.set_variable, memory)
             elif misc.llm_query:
                 await run_llm_query_action(misc.llm_query, memory, task)
+            elif misc.count_locator:
+                await run_count_locator_action(misc.count_locator, memory, browser)
 
     except Exception as e:
         logger.error(f"Error running node {memory.automation_state.step_index}: {e}")
@@ -625,52 +628,54 @@ async def _wait_for_stable_locator_count(locator) -> int:
             stable_since = time.monotonic()
 
 
-async def _count_locator_matches(for_loop_node: ForLoopNode, browser: Browser) -> int:
-    """Number of elements a locator loop should iterate over.
+async def count_locator_matches(
+    locator_command: str, locator_timeout: float, browser: Browser
+) -> int:
+    """Number of elements a Playwright locator matches on the current page.
 
     Playwright's ``count()`` does not auto-wait, so give the first match a chance
     to attach first: results tables are usually rendered a moment after the
     action that triggers them, and sleep_for_page_to_load returns immediately
-    once the page has loaded. Counting straight away would see zero rows and
-    silently skip the whole loop body.
+    once the page has loaded. Counting straight away would see zero rows.
 
     After the first match attaches, the count must stay unchanged for
     ``_LOCATOR_COUNT_STABLE_SECONDS`` so rows that stream in shortly after the
     first paint are included. A locator that resolves but never attaches means
-    zero rows, which is a legitimate outcome (empty result table) rather than
+    zero matches, which is a legitimate outcome (empty result table) rather than
     an error.
     """
-    assert for_loop_node.locator is not None
-    locator = await browser.get_locator_from_command(for_loop_node.locator)
+    locator = await browser.get_locator_from_command(locator_command)
     if locator is None:
         # Only happens when the browser/page itself is gone, not when the
-        # selector matches nothing, so surface it instead of looping zero times.
-        raise ValueError(
-            f"Could not resolve locator {for_loop_node.locator!r} for for_loop_node"
-        )
+        # selector matches nothing.
+        raise ValueError(f"Could not resolve locator {locator_command!r}")
 
-    if for_loop_node.locator_timeout > 0:
+    if locator_timeout > 0:
         try:
             await locator.first.wait_for(
-                state="attached", timeout=for_loop_node.locator_timeout * 1000
+                state="attached", timeout=locator_timeout * 1000
             )
         except (TimeoutError, PatchrightTimeoutError, PlaywrightTimeoutError):
             logger.warning(
-                f"No matching locator found: {for_loop_node.locator!r} "
-                f"(waited {for_loop_node.locator_timeout}s); "
-                f"for loop will run zero iterations"
+                f"No matching locator found: {locator_command!r} "
+                f"(waited {locator_timeout}s); count=0"
             )
             return 0
     elif await locator.count() == 0:
-        logger.warning(
-            f"No matching locator found: {for_loop_node.locator!r}; "
-            f"for loop will run zero iterations"
-        )
+        logger.warning(f"No matching locator found: {locator_command!r}; count=0")
         return 0
 
     count = await _wait_for_stable_locator_count(locator)
-    logger.debug(f"Locator {for_loop_node.locator!r} matched {count} element(s)")
+    logger.debug(f"Locator {locator_command!r} matched {count} element(s)")
     return count
+
+
+async def _count_locator_matches(for_loop_node: ForLoopNode, browser: Browser) -> int:
+    """Number of elements a locator loop should iterate over."""
+    assert for_loop_node.locator is not None
+    return await count_locator_matches(
+        for_loop_node.locator, for_loop_node.locator_timeout, browser
+    )
 
 
 async def handle_for_loop_node(

--- a/optexity/inference/core/run_misc.py
+++ b/optexity/inference/core/run_misc.py
@@ -5,6 +5,7 @@ import traceback
 from optexity.inference.infra.browser import Browser
 from optexity.inference.models import get_llm_model_with_fallback
 from optexity.schema.actions.misc_action import (
+    CountLocatorAction,
     FailStateAction,
     LLMQueryAction,
     SetVariableAction,
@@ -45,6 +46,29 @@ async def run_set_variable_action(
     else:
         result = eval(set_variable_action.expression)  # noqa: S307
         memory.variables.generated_variables[name] = [result]
+    logger.debug(
+        f"Set variable '{name}' = {memory.variables.generated_variables[name]}"
+    )
+
+
+async def run_count_locator_action(
+    count_locator_action: CountLocatorAction,
+    memory: Memory,
+    browser: Browser,
+):
+    # Imported lazily to avoid a circular import with run_automation.
+    from optexity.inference.core.run_automation import count_locator_matches
+
+    logger.debug(
+        f"---------Running count_locator action {count_locator_action.model_dump_json()}---------"
+    )
+    count = await count_locator_matches(
+        count_locator_action.locator,
+        count_locator_action.locator_timeout,
+        browser,
+    )
+    name = count_locator_action.name
+    memory.variables.generated_variables[name] = [count]
     logger.debug(
         f"Set variable '{name}' = {memory.variables.generated_variables[name]}"
     )

--- a/optexity/schema/actions/misc_action.py
+++ b/optexity/schema/actions/misc_action.py
@@ -89,6 +89,28 @@ class SetVariableAction(BaseModel):
         return self
 
 
+class CountLocatorAction(BaseModel):
+    """Count how many elements a Playwright locator matches on the current page.
+
+    The integer count is stored in generated_variables under `name` as a
+    single-element list (same wrapping as set_variable).
+    """
+
+    locator: str
+    name: str
+    locator_timeout: float = 5.0
+
+    @model_validator(mode="after")
+    def validate_timeout(self):
+        if self.locator_timeout < 0:
+            raise ValueError("locator_timeout must not be negative")
+        return self
+
+    def replace(self, pattern: str, replacement: str):
+        self.locator = self.locator.replace(pattern, replacement)
+        return self
+
+
 class MiscAction(BaseModel):
     """Container for miscellaneous actions (set_variable, llm_query, etc.).
 
@@ -97,12 +119,15 @@ class MiscAction(BaseModel):
 
     set_variable: SetVariableAction | None = None
     llm_query: LLMQueryAction | None = None
+    count_locator: CountLocatorAction | None = None
 
     def replace(self, pattern: str, replacement: str):
         if self.set_variable:
             self.set_variable.replace(pattern, replacement)
         if self.llm_query:
             self.llm_query.replace(pattern, replacement)
+        if self.count_locator:
+            self.count_locator.replace(pattern, replacement)
         return self
 
 


### PR DESCRIPTION
Store a Playwright locator's stable match count in generated_variables, reusing the same attach-wait and stable-count logic as locator for-loops.