### PR TITLE
feat: optional output_variable_name on set_variable and count_locator

### DIFF
--- a/docs/docs-manifest.json
+++ b/docs/docs-manifest.json
@@ -518,7 +518,7 @@
             "id": "docs-action-types-count-locator-action",
             "path": "docs/action-types/count-locator-action.mdx",
             "title": "Count Locator Action",
-            "summary": "Documents misc_action.count_locator — counts Playwright locator matches on the current page and stores the integer in generated_variables. Covers locator, name, locator_timeout, stable-count wait semantics shared with locator for-loops, and when to use count_locator vs a locator for_loop_node.",
+            "summary": "Documents misc_action.count_locator — counts Playwright locator matches on the current page and stores the integer in generated_variables. Covers locator, name, locator_timeout, optional output_variable_name for task output_data, placeholder expansion on name/output_variable_name, stable-count wait semantics shared with locator for-loops, and when to use count_locator vs a locator for_loop_node.",
             "gist": "Count how many elements a Playwright locator matches and store the result as a generated variable for branching or thresholds.",
             "keywords": [
                 "count_locator",
@@ -528,6 +528,8 @@
                 "locator_timeout",
                 "count",
                 "generated_variables",
+                "output_variable_name",
+                "output_data",
                 "Playwright",
                 "match count",
                 "stable count"
@@ -554,8 +556,8 @@
                 "data_models": ["CountLocatorAction", "MiscAction"]
             },
             "reading_priority": 2,
-            "when_to_use": "Select when the query is about misc_action.count_locator, counting Playwright locator matches on a page, storing a match count in generated_variables, locator_timeout for counting, or choosing between count_locator and a locator for_loop_node.",
-            "embedding_hint": "count locator misc action match count generated_variables locator_timeout stable count pagination empty table"
+            "when_to_use": "Select when the query is about misc_action.count_locator, counting Playwright locator matches on a page, storing a match count in generated_variables, output_variable_name for output_data, locator_timeout for counting, or choosing between count_locator and a locator for_loop_node.",
+            "embedding_hint": "count locator misc action match count generated_variables output_variable_name output_data locator_timeout stable count pagination empty table"
         },
         {
             "id": "docs-action-types-sleep-action",

--- a/docs/docs/action-types/count-locator-action.mdx
+++ b/docs/docs/action-types/count-locator-action.mdx
@@ -16,8 +16,9 @@ Use `misc_action.count_locator` to count Playwright locator matches on the curre
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `locator` | `str` | Required | Playwright locator command evaluated against `page`, e.g. `get_by_role("row")` |
-| `name` | `str` | Required | Key written into `generated_variables` as a single-element list `[count]` |
+| `name` | `str` | Required | Key written into `generated_variables` as a single-element list `[count]`. Accepts placeholders (e.g. `"rows_{index}"`) |
 | `locator_timeout` | `float` | `5.0` | Seconds to wait for the first match to attach before counting; `0` skips the attach wait |
+| `output_variable_name` | `str \| None` | `None` | When set, also append the count to task `output_data` under this key. Accepts placeholders |
 
 ## JSON Example
 
@@ -34,6 +35,20 @@ Use `misc_action.count_locator` to count Playwright locator matches on the curre
 ```
 
 After this action, `{row_count[0]}` is available in subsequent nodes (including `if_else_node` conditions and `set_variable` expressions).
+
+To also include the count in the task output payload, set `output_variable_name`:
+
+```json
+{
+  "misc_action": {
+    "count_locator": {
+      "locator": "get_by_role(\"row\")",
+      "name": "row_count",
+      "output_variable_name": "row_count"
+    }
+  }
+}
+```
 
 ## Waiting for Matches
 

--- a/optexity/inference/core/run_misc.py
+++ b/optexity/inference/core/run_misc.py
@@ -33,6 +33,17 @@ async def run_fail_state_action(
     raise Exception(fail_state_action.failure_message)
 
 
+def _maybe_append_output_data(memory: Memory, output_variable_name: str | None, value):
+    if output_variable_name is None:
+        return
+    memory.variables.output_data.append(
+        OutputData(
+            unique_identifier=output_variable_name,
+            json_data={output_variable_name: value},
+        )
+    )
+
+
 async def run_set_variable_action(
     set_variable_action: SetVariableAction,
     memory: Memory,
@@ -42,10 +53,11 @@ async def run_set_variable_action(
     )
     name = set_variable_action.name
     if set_variable_action.value is not None:
-        memory.variables.generated_variables[name] = [set_variable_action.value]
+        value = set_variable_action.value
     else:
-        result = eval(set_variable_action.expression)  # noqa: S307
-        memory.variables.generated_variables[name] = [result]
+        value = eval(set_variable_action.expression)  # noqa: S307
+    memory.variables.generated_variables[name] = [value]
+    _maybe_append_output_data(memory, set_variable_action.output_variable_name, value)
     logger.debug(
         f"Set variable '{name}' = {memory.variables.generated_variables[name]}"
     )
@@ -69,6 +81,7 @@ async def run_count_locator_action(
     )
     name = count_locator_action.name
     memory.variables.generated_variables[name] = [count]
+    _maybe_append_output_data(memory, count_locator_action.output_variable_name, count)
     logger.debug(
         f"Set variable '{name}' = {memory.variables.generated_variables[name]}"
     )

--- a/optexity/schema/actions/misc_action.py
+++ b/optexity/schema/actions/misc_action.py
@@ -69,11 +69,15 @@ class SetVariableAction(BaseModel):
 
     Use `value` for a static value, or `expression` for a computed value
     (evaluated after variable replacement, e.g. "{counter[0]} + 1").
+
+    When `output_variable_name` is set, the value is also appended to
+    ``output_data`` under that key.
     """
 
     name: str
     value: int | float | str | bool | None = None
     expression: str | None = None
+    output_variable_name: str | None = None
 
     @model_validator(mode="after")
     def validate_one_provided(self):
@@ -84,8 +88,13 @@ class SetVariableAction(BaseModel):
         return self
 
     def replace(self, pattern: str, replacement: str):
+        self.name = self.name.replace(pattern, replacement)
         if self.expression:
             self.expression = self.expression.replace(pattern, replacement)
+        if self.output_variable_name is not None:
+            self.output_variable_name = self.output_variable_name.replace(
+                pattern, replacement
+            )
         return self
 
 
@@ -94,11 +103,15 @@ class CountLocatorAction(BaseModel):
 
     The integer count is stored in generated_variables under `name` as a
     single-element list (same wrapping as set_variable).
+
+    When `output_variable_name` is set, the count is also appended to
+    ``output_data`` under that key.
     """
 
     locator: str
     name: str
     locator_timeout: float = 5.0
+    output_variable_name: str | None = None
 
     @model_validator(mode="after")
     def validate_timeout(self):
@@ -108,6 +121,11 @@ class CountLocatorAction(BaseModel):
 
     def replace(self, pattern: str, replacement: str):
         self.locator = self.locator.replace(pattern, replacement)
+        self.name = self.name.replace(pattern, replacement)
+        if self.output_variable_name is not None:
+            self.output_variable_name = self.output_variable_name.replace(
+                pattern, replacement
+            )
         return self
 
 


### PR DESCRIPTION
Allow misc set_variable/count_locator to append to task output_data when output_variable_name is set, and expand placeholders on name fields.