### PR TITLE
docs: fix Mintlify deployment failure (stale final_screenshot nav entry)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,7 +95,6 @@
                         "pages": [
                             "POST /api/v1/inference",
                             "GET /api/v1/task_status",
-                            "GET /api/v1/final_screenshot",
                             "GET /api/v1/get_output_data",
                             "GET /api/v1/get_downloads",
                             "POST /api/v1/initiate_callback",


### PR DESCRIPTION
## Problem

`docs.optexity.com` has not updated since #205 (2026-08-17). Every `main` build since #211 (2026-08-24) has failed:

> **Mintlify Deployment — Deployment Failed**
> `Failed to fetch OpenAPI file for anchor or tab`

## Root cause

The `HTTP API` group in `docs/docs.json` lists `GET /api/v1/final_screenshot`, but that path does not exist in the OpenAPI spec — not in the vendored `docs/openapi.json`, and not in the live `https://api.optexity.com/openapi.json` (32 paths, none matching). `final_screenshot` is only a *field* in the callback payload, not an endpoint.

Mintlify aborts the entire build when a navigation entry cannot be resolved against the spec. Reproduced locally:

```
$ mint dev
error Endpoint /api/v1/final_screenshot not found in openapi.json
```

Switching the `openapi` field from the remote URL to the vendored file in #212 did not help, because the missing endpoint was the actual problem.

## Fix

Remove the stale nav entry. Verified locally — `mint dev` now reaches `✓ preview ready`.

## Note on PR previews

The `Mintlify Deployment` check reports `Skipping deployment — No eligible deployments found for changes` on **every** PR, including ones that only touch `.mdx` files, going back to at least #194 (2026-08-06). That is a separate, pre-existing config issue (preview deployments are not enabled for this project in the Mintlify dashboard) — it is not a regression, but it means this fix can only be confirmed once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)